### PR TITLE
ISC is not known to PGXN, so spell it out.

### DIFF
--- a/META.json
+++ b/META.json
@@ -9,7 +9,6 @@
    "license": {
      "ISC": "http://www.opensource.org/licenses/ISC"
    },
-   "license": "isc",
    "provides": {
       "plproxy": {
          "abstract": "Database partitioning implemented as procedural language",


### PR DESCRIPTION
I've started the process of [making it known](https://github.com/rjbs/software-license/pull/7), but in the meantime, this is the way to specify a license that PGXN does not know about.
