### PR TITLE
Fix build with PostgreSQL 9.3devel

### DIFF
--- a/src/plproxy.h
+++ b/src/plproxy.h
@@ -37,12 +37,17 @@
 #include <catalog/pg_user_mapping.h>
 #endif
 
+#if PG_VERSION_NUM >= 90300
+#include <access/htup_details.h>
+#endif
+
 #include <access/reloptions.h>
 #include <access/tupdesc.h>
 #include <catalog/pg_namespace.h>
 #include <catalog/pg_proc.h>
 #include <catalog/pg_type.h>
 #include <commands/trigger.h>
+#include <lib/stringinfo.h>
 #include <mb/pg_wchar.h>
 #include <miscadmin.h>
 #include <nodes/value.h>


### PR DESCRIPTION
Some needed declarations have been moved to the new header
htup_details.h.

stringinfo.h needs to be included explicitly now.  It should always have
been necessary, but might have come in through other headers.
