### PR TITLE
rpm packaging and standalone tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -154,6 +154,16 @@ deb:
 debclean:
 	$(MAKE) -f debian/rules realclean
 
+# rpm build hack to set the minor version number to git id
+rpm:
+	git archive --output=plproxy-rpm-src.tar.gz --prefix=plproxy/ HEAD
+	rpmbuild -ta plproxy-rpm-src.tar.gz \
+		--define "major_version $(DISTVERSION)" \
+		--define "minor_version `git describe --tags --long --always | \
+		                         sed -e s,\`git describe --tags --abbrev=0 --always\`-,, \
+		                             -e s,-,.,g`"
+	$(RM) plproxy-rpm-src.tar.gz
+
 orig:
 	make -f debian/rules orig
 

--- a/Makefile
+++ b/Makefile
@@ -158,6 +158,7 @@ debclean:
 rpm:
 	git archive --output=plproxy-rpm-src.tar.gz --prefix=plproxy/ HEAD
 	rpmbuild -ta plproxy-rpm-src.tar.gz \
+		--define "ext_version $(EXTVERSION)" \
 		--define "major_version $(DISTVERSION)" \
 		--define "minor_version `git describe --tags --long --always | \
 		                         sed -e s,\`git describe --tags --abbrev=0 --always\`-,, \

--- a/plproxy.spec
+++ b/plproxy.spec
@@ -1,0 +1,39 @@
+Name:           plproxy
+Version:        %{major_version}
+Release:        %{minor_version}%{?dist}
+Summary:        PostgreSQL partitioning system
+
+Group:          Applications/Databases
+License:        ISC
+Source0:        plproxy-rpm-src.tar.gz
+Requires:       postgresql-server
+BuildRequires:  flex, bison
+
+%description
+PL/Proxy is a database partitioning system implemented as PL language.  The
+main idea is that proxy function will be created with same signature as
+remote function to be called, so only destination info needs to be specified
+inside proxy function body.
+
+%prep
+%setup -q -n %{name}
+
+%build
+make
+
+%install
+rm -rf %{buildroot}
+make install DESTDIR=%{buildroot}
+
+%clean
+rm -rf %{buildroot}
+
+%files
+%defattr(-,root,root,-)
+%doc AUTHORS COPYRIGHT NEWS README doc/*
+%{_libdir}/pgsql/plproxy.so
+%{_datadir}/pgsql/extension/plproxy*
+
+%changelog
+* Wed Aug 21 2013 Oskari Saarenmaa <os@ohmu.fi> - 2.5-8.g294e9a5
+- Initial.

--- a/plproxy.spec
+++ b/plproxy.spec
@@ -28,6 +28,9 @@ make install DESTDIR=%{buildroot}
 %clean
 rm -rf %{buildroot}
 
+%check
+EXTVERSION=%{ext_version} ./runtests.sh
+
 %files
 %defattr(-,root,root,-)
 %doc AUTHORS COPYRIGHT NEWS README doc/*

--- a/runtests.sh
+++ b/runtests.sh
@@ -1,0 +1,28 @@
+#!/bin/bash -xue
+
+export TESTDIR="$(pwd)/regressiondata"
+export PGPORT=$((10240 + RANDOM / 2))
+export PGDATA="$TESTDIR/pg"
+rm -rf "$TESTDIR"
+mkdir -p "$PGDATA"
+initdb -E UTF-8 --no-locale --nosync
+sed -e "s%^#port =.*%port = $PGPORT%" \
+    -e "s%^#\(unix_socket_director[a-z]*\) =.*%\1 = '$PGDATA'%" \
+    -e "s%^#dynamic_library_path = .*%dynamic_library_path = '$(pwd):\$libdir'%" \
+    -e "s%^#fsync = .*%fsync = off%" \
+    -e "s%^#synchronous_commit = .*%synchronous_commit = off%" \
+    -i "$PGDATA/postgresql.conf"
+pg_ctl -l "$PGDATA/log" start
+while [ ! -S "$PGDATA/.s.PGSQL.$PGPORT" ]; do sleep 2; done
+trap "pg_ctl stop -m immediate" EXIT
+
+cp -a "test/" "sql/" "$TESTDIR/"
+echo "\\i sql/plproxy--$EXTVERSION.sql" > "$TESTDIR/sql/plproxy.sql"
+find "$TESTDIR/test" -type f -print0 | xargs -0r \
+	sed -e "s%host=.*dbname=%host=$PGDATA port=$PGPORT dbname=%" -i
+cd "$TESTDIR"
+/usr/lib64/pgsql/pgxs/src/makefiles/../../src/test/regress/pg_regress \
+    --host="$PGDATA" --port="$PGPORT" \
+    --inputdir=. --psqldir='/usr/bin' \
+    --dbname=regression --inputdir=test --dbname=regression \
+    plproxy_init plproxy_test plproxy_select plproxy_many plproxy_errors plproxy_clustermap plproxy_dynamic_record plproxy_encoding plproxy_split plproxy_target plproxy_alter plproxy_cancel plproxy_sqlmed plproxy_table plproxy_range

--- a/test/expected/plproxy_sqlmed.out
+++ b/test/expected/plproxy_sqlmed.out
@@ -1,10 +1,10 @@
 \set VERBOSITY terse
 set client_min_messages = 'warning';
-create server sqlmedcluster foreign data wrapper plproxy 
-    options (   partition_0 'dbname=test_part3 host=localhost',
-                partition_1 'dbname=test_part2 host=localhost',
-                partition_2 'dbname=test_part1 host=localhost',
-                partition_3 'dbname=test_part0 host=localhost');
+create server sqlmedcluster foreign data wrapper plproxy
+    options (   partition_0 'host=localhost dbname=test_part3',
+                partition_1 'host=localhost dbname=test_part2',
+                partition_2 'host=localhost dbname=test_part1',
+                partition_3 'host=localhost dbname=test_part0');
 create or replace function sqlmed_test1() returns setof text as $$
     cluster 'sqlmedcluster';
     run on 0;
@@ -110,9 +110,9 @@ select * from sqlmed_test1();
 (1 row)
 
 -- invalid partition count
-alter server sqlmedcluster options 
+alter server sqlmedcluster options
     (drop partition_3,
-     add  partition_2 'dbname=test_part1 host=localhost');
+     add  partition_2 'host=localhost dbname=test_part1');
 ERROR:  option "partition_2" provided more than once
 select * from sqlmed_test1();
                  sqlmed_test1                  
@@ -135,8 +135,8 @@ select * from sqlmed_compat_test();
 
 -- override the test cluster with a SQL/MED definition
 drop server if exists testcluster cascade;
-create server testcluster foreign data wrapper plproxy 
-    options (partition_0 'dbname=regression host=localhost');
+create server testcluster foreign data wrapper plproxy
+    options (partition_0 'host=localhost dbname=regression');
 create user mapping for public server testcluster;
 -- sqlmed testcluster
 select * from sqlmed_compat_test();

--- a/test/expected/plproxy_test.out
+++ b/test/expected/plproxy_test.out
@@ -244,7 +244,7 @@ select * from test_types2('types', NULL, NULL, NULL);
 
 -- test CONNECT
 create function test_connect1() returns text
-as $$ connect 'dbname=test_part'; select current_database(); $$ language plproxy;
+as $$ connect 'host=127.0.0.1 dbname=test_part'; select current_database(); $$ language plproxy;
 select * from test_connect1();
  test_connect1 
 ---------------
@@ -254,7 +254,7 @@ select * from test_connect1();
 -- test CONNECT $argument
 create function test_connect2(connstr text) returns text
 as $$ connect connstr; select current_database(); $$ language plproxy;
-select * from test_connect2('dbname=test_part');
+select * from test_connect2('host=127.0.0.1 dbname=test_part');
  test_connect2 
 ---------------
  test_part
@@ -263,7 +263,7 @@ select * from test_connect2('dbname=test_part');
 -- test CONNECT function($argument)
 create function test_connect3(connstr text) returns text
 as $$ connect text(connstr); select current_database(); $$ language plproxy;
-select * from test_connect3('dbname=test_part');
+select * from test_connect3('host=127.0.0.1 dbname=test_part');
  test_connect3 
 ---------------
  test_part
@@ -409,7 +409,7 @@ NOTICE:  PL/Proxy: dropping stale conn
 ERROR:  public.test_error2(0): [test_part] REMOTE ERROR: column "err" does not exist at character 8
 create function test_error3() returns int4
 as $$
-    connect 'dbname=test_part';
+    connect 'host=127.0.0.1 dbname=test_part';
 $$ language plproxy;
 select * from test_error3();
 ERROR:  public.test_error3(0): [test_part] REMOTE ERROR: function public.test_error3() does not exist at character 21
@@ -423,7 +423,7 @@ ERROR:  PL/Proxy function public.test_bad_db(0): [nonex_db] PQconnectPoll: FATAL
 
 create function test_bad_db2() returns int4
 as $$
-    connect 'dbname=wrong_name_db';
+    connect 'host=127.0.0.1 dbname=wrong_name_db';
 $$ language plproxy;
 select * from test_bad_db2();
 ERROR:  PL/Proxy function public.test_bad_db2(0): [wrong_name_db] PQconnectPoll: FATAL:  database "wrong_name_db" does not exist

--- a/test/sql/plproxy_init.sql
+++ b/test/sql/plproxy_init.sql
@@ -28,11 +28,11 @@ plproxy.get_cluster_partitions(cluster_name text)
 returns setof text as $$
 begin
     if cluster_name = 'testcluster' then
-        return next 'host=127.0.0.1 dbname=test_part';
+        return next 'host=/home/saaros/dev/plproxy/regressiondb port=12865 dbname=test_part';
         return;
     end if;
     if cluster_name = 'badcluster' then
-        return next 'host=127.0.0.1 dbname=nonex_db';
+        return next 'host=/home/saaros/dev/plproxy/regressiondb port=12865 dbname=nonex_db';
         return;
     end if;
     raise exception 'no such cluster: %', cluster_name;

--- a/test/sql/plproxy_sqlmed.sql
+++ b/test/sql/plproxy_sqlmed.sql
@@ -2,11 +2,11 @@
 \set VERBOSITY terse
 set client_min_messages = 'warning';
 
-create server sqlmedcluster foreign data wrapper plproxy 
-    options (   partition_0 'dbname=test_part3 host=localhost',
-                partition_1 'dbname=test_part2 host=localhost',
-                partition_2 'dbname=test_part1 host=localhost',
-                partition_3 'dbname=test_part0 host=localhost');
+create server sqlmedcluster foreign data wrapper plproxy
+    options (   partition_0 'host=localhost dbname=test_part3',
+                partition_1 'host=localhost dbname=test_part2',
+                partition_2 'host=localhost dbname=test_part1',
+                partition_3 'host=localhost dbname=test_part0');
 
 create or replace function sqlmed_test1() returns setof text as $$
     cluster 'sqlmedcluster';
@@ -91,9 +91,9 @@ alter server sqlmedcluster options (drop partition_2);
 select * from sqlmed_test1();
 
 -- invalid partition count
-alter server sqlmedcluster options 
+alter server sqlmedcluster options
     (drop partition_3,
-     add  partition_2 'dbname=test_part1 host=localhost');
+     add  partition_2 'host=localhost dbname=test_part1');
 select * from sqlmed_test1();
 
 -- switching betweem SQL/MED and compat mode
@@ -109,8 +109,8 @@ select * from sqlmed_compat_test();
 
 -- override the test cluster with a SQL/MED definition
 drop server if exists testcluster cascade;
-create server testcluster foreign data wrapper plproxy 
-    options (partition_0 'dbname=regression host=localhost');
+create server testcluster foreign data wrapper plproxy
+    options (partition_0 'host=localhost dbname=regression');
 create user mapping for public server testcluster;
 
 -- sqlmed testcluster

--- a/test/sql/plproxy_test.sql
+++ b/test/sql/plproxy_test.sql
@@ -145,18 +145,18 @@ select * from test_types2('types', NULL, NULL, NULL);
 
 -- test CONNECT
 create function test_connect1() returns text
-as $$ connect 'dbname=test_part'; select current_database(); $$ language plproxy;
+as $$ connect 'host=127.0.0.1 dbname=test_part'; select current_database(); $$ language plproxy;
 select * from test_connect1();
 
 -- test CONNECT $argument
 create function test_connect2(connstr text) returns text
 as $$ connect connstr; select current_database(); $$ language plproxy;
-select * from test_connect2('dbname=test_part');
+select * from test_connect2('host=127.0.0.1 dbname=test_part');
 
 -- test CONNECT function($argument)
 create function test_connect3(connstr text) returns text
 as $$ connect text(connstr); select current_database(); $$ language plproxy;
-select * from test_connect3('dbname=test_part');
+select * from test_connect3('host=127.0.0.1 dbname=test_part');
 
 -- test quoting function
 create type "RetWeird" as (
@@ -272,7 +272,7 @@ select * from test_error2();
 
 create function test_error3() returns int4
 as $$
-    connect 'dbname=test_part';
+    connect 'host=127.0.0.1 dbname=test_part';
 $$ language plproxy;
 select * from test_error3();
 
@@ -285,7 +285,7 @@ select * from test_bad_db();
 
 create function test_bad_db2() returns int4
 as $$
-    connect 'dbname=wrong_name_db';
+    connect 'host=127.0.0.1 dbname=wrong_name_db';
 $$ language plproxy;
 select * from test_bad_db2();
 


### PR DESCRIPTION
- packaging: add rpm building support
- runtests.sh: set up a new postgresql cluster and run tests there

This allows running tests without installing plproxy and should not conflict with any other PostgreSQL instances.  There are a couple of hacks in runtests.sh to work around limitations in installing extensions from outside the global postgresql share directory.

Also reformatted all connection strings in existing test cases to set the target hostname as the first field so we can rewrite it when running tests.
