### PR TITLE
Fix yy_scan_bytes() prototype

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,9 +98,11 @@ src/parser.tab.c: src/parser.y
 	@mkdir -p src
 	$(BISON) -b src/parser -d $<
 
+src/parser.o: src/scanner.h
+src/scanner.h: src/scanner.c
 src/scanner.c: src/scanner.l
 	@mkdir -p src
-	$(FLEX) -o$@ $<
+	$(FLEX) -o$@ --header-file=$(@:.c=.h) $<
 
 sql/plproxy.sql: $(PLPROXY_SQL)
 	@mkdir -p sql

--- a/src/parser.y
+++ b/src/parser.y
@@ -19,9 +19,7 @@
  */
 
 #include "plproxy.h"
-
-/* define scanner.c functions */
-void plproxy_yy_scan_bytes(const char *bytes, int len);
+#include "scanner.h"
 
 /* avoid permanent allocations */
 #define YYMALLOC palloc


### PR DESCRIPTION
Flex changed the second argument of yy_scan_bytes() from int to size_t a
great while ago, while not updating the documentation.  To make the
prototype in plproxy match, use flex --header-file to create a header
file, and include that, instead of maintaining an explicit prototype
ourselves.

See also:
- https://sourceforge.net/p/flex/bugs/184/
- https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=750163
