### PR TITLE
Fix deprecated Bison syntax.

### DIFF
--- a/src/parser.y
+++ b/src/parser.y
@@ -53,7 +53,7 @@ static void reset_parser_vars(void)
 
 %}
 
-%name-prefix="plproxy_yy"
+%name-prefix "plproxy_yy"
 
 %token <str> CONNECT CLUSTER RUN ON ALL ANY SELECT
 %token <str> IDENT NUMBER FNCALL SPLIT STRING


### PR DESCRIPTION
Fixes this warning.

```src/parser.y:56.1-13: warning: deprecated directive, use '%name-prefix' [-Wdeprecated]
 %name-prefix="plproxy_yy"```