### PR TITLE
Fix tests on PostgreSQL 9.6

### DIFF
--- a/test/expected/plproxy_errors.out
+++ b/test/expected/plproxy_errors.out
@@ -1,3 +1,4 @@
+\set VERBOSITY terse
 -- test bad arg
 create function test_err1(dat text)
 returns text as $$
@@ -5,10 +6,7 @@ returns text as $$
     run on hashtext(username);
 $$ language plproxy;
 select * from test_err1('dat');
-ERROR:  column "username" does not exist
-LINE 1: select * from hashtext(username)
-                               ^
-QUERY:  select * from hashtext(username)
+ERROR:  column "username" does not exist at character 24
 create function test_err2(dat text)
 returns text as $$
     cluster 'testcluster';
@@ -16,10 +14,7 @@ returns text as $$
 $$ language plproxy;
 ERROR:  PL/Proxy function public.test_err2(1): Compile error at line 3: invalid argument reference: $2
 select * from test_err2('dat');
-ERROR:  function test_err2(unknown) does not exist
-LINE 1: select * from test_err2('dat');
-                      ^
-HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+ERROR:  function test_err2(unknown) does not exist at character 15
 create function test_err3(dat text)
 returns text as $$
     cluster 'nonexists';
@@ -27,7 +22,6 @@ returns text as $$
 $$ language plproxy;
 select * from test_err3('dat');
 ERROR:  no such cluster: nonexists
-CONTEXT:  SQL statement "select * from plproxy.get_cluster_version($1)"
 -- should work
 create function test_err_none(dat text)
 returns text as $$
@@ -68,20 +62,14 @@ returns record as $$
 $$ language plproxy;
 ERROR:  PL/Proxy function public.test_map_err4(1): Compile error at line 5: CLUSTER statement missing
 select * from test_map_err4('dat');
-ERROR:  function test_map_err4(unknown) does not exist
-LINE 1: select * from test_map_err4('dat');
-                      ^
-HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+ERROR:  function test_map_err4(unknown) does not exist at character 15
 create function test_variadic_err(first text, rest variadic text[])
 returns text as $$
     cluster 'testcluster';
 $$ language plproxy;
 ERROR:  PL/Proxy does not support variadic args
 select * from test_variadic_err('dat', 'dat', 'dat');
-ERROR:  function test_variadic_err(unknown, unknown, unknown) does not exist
-LINE 1: select * from test_variadic_err('dat', 'dat', 'dat');
-                      ^
-HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+ERROR:  function test_variadic_err(unknown, unknown, unknown) does not exist at character 15
 create function test_volatile_err(dat text)
 returns text
 stable
@@ -90,10 +78,7 @@ as $$
 $$ language plproxy;
 ERROR:  PL/Proxy functions must be volatile
 select * from test_volatile_err('dat');
-ERROR:  function test_volatile_err(unknown) does not exist
-LINE 1: select * from test_volatile_err('dat');
-                      ^
-HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+ERROR:  function test_volatile_err(unknown) does not exist at character 15
 create function test_pseudo_arg_err(dat cstring)
 returns text
 as $$
@@ -101,10 +86,7 @@ as $$
 $$ language plproxy;
 ERROR:  PL/Proxy function public.test_pseudo_arg_err(0): unsupported pseudo type: cstring (2275)
 select * from test_pseudo_arg_err(textout('dat'));
-ERROR:  function test_pseudo_arg_err(cstring) does not exist
-LINE 1: select * from test_pseudo_arg_err(textout('dat'));
-                      ^
-HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+ERROR:  function test_pseudo_arg_err(cstring) does not exist at character 15
 create function test_pseudo_ret_err(dat text)
 returns cstring
 as $$
@@ -121,10 +103,7 @@ as $$
 $$ language plproxy;
 ERROR:  PL/Proxy function public.test_runonall_err(1): RUN ON ALL requires set-returning function
 select * from test_runonall_err('dat');
-ERROR:  function test_runonall_err(unknown) does not exist
-LINE 1: select * from test_runonall_err('dat');
-                      ^
-HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+ERROR:  function test_runonall_err(unknown) does not exist at character 15
 -- make sure that errors from non-setof functions returning <> 1 row have
 -- a proper sqlstate
 create function test_no_results_plproxy()

--- a/test/sql/plproxy_errors.sql
+++ b/test/sql/plproxy_errors.sql
@@ -1,3 +1,4 @@
+\set VERBOSITY terse
 
 -- test bad arg
 create function test_err1(dat text)


### PR DESCRIPTION
The output of the CONTEXT field in error messages has changed in
PostgreSQL 9.6 to include more detail:

```
 ERROR:  no such cluster: nonexists
-CONTEXT:  SQL statement "select * from plproxy.get_cluster_version($1)"
+CONTEXT:  PL/pgSQL function plproxy.get_cluster_version(text) line 6 at RAISE
+SQL statement "select * from plproxy.get_cluster_version($1)"
 -- should work
```

Since those details are not material to the test here, avoid the differences by setting psql to
"terse" verbosity.