### PR TITLE
Allow unordered partitions in CREATE SERVER

### DIFF
--- a/test/expected/plproxy_sqlmed.out
+++ b/test/expected/plproxy_sqlmed.out
@@ -102,7 +102,7 @@ reset session authorization;
 -- cluster definition validation
 -- partition numbers must be consecutive
 alter server sqlmedcluster options (drop partition_2);
-ERROR:  Pl/Proxy: partitions must be numbered consecutively
+ERROR:  Pl/Proxy: invalid number of partitions
 select * from sqlmed_test1();
                  sqlmed_test1                  
 -----------------------------------------------


### PR DESCRIPTION
This fix load from pg_dump if partition names like p0, p1, etc.
See issue plproxy/plproxy#21
