### PR TITLE
Support more than one digit versions in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,9 +52,12 @@ EXTSQL = sql/$(EXTENSION)--$(EXTVERSION).sql \
 
 # PostgreSQL version
 PGVER = $(shell $(PG_CONFIG) --version | sed 's/PostgreSQL //')
-SQLMED = $(shell test "$(PGVER)" "<" "8.4" && echo "false" || echo "true")
-PG91 = $(shell test "$(PGVER)" "<" "9.1" && echo "false" || echo "true")
-PG92 = $(shell test "$(PGVER)" "<" "9.2" && echo "false" || echo "true")
+PGMAJOR = $(shell echo $(PGVER) | cut -d'.' -f1 | sed -r "s/([0-9]+)(((beta)|(alpha)|(rc))[0-9]*)?/\1/")
+PGMINOR = $(shell echo $(PGVER) | cut -d'.' -f2 | sed -r "s/([0-9]+)(((beta)|(alpha)|(rc))[0-9]*)?/\1/")
+
+SQLMED = $(shell test $(PGMAJOR) -lt 8 -o \( $(PGMAJOR) -eq 8 -a $(PGMINOR) -lt 4 \) && echo "false" || echo "true")
+PG91 = $(shell test $(PGMAJOR) -lt 9 -o \( $(PGMAJOR) -eq 9 -a $(PGMINOR) -lt 1 \) && echo "false" || echo "true")
+PG92 = $(shell test $(PGMAJOR) -lt 9 -o \( $(PGMAJOR) -eq 9 -a $(PGMINOR) -lt 2 \) && echo "false" || echo "true")
 
 # SQL/MED available, add foreign data wrapper and regression tests
 ifeq ($(SQLMED), true)


### PR DESCRIPTION
The string comparisson of PG versions was returning true to any
comparisson of 10 or any other greater version with 9.x or 8.4 versions.
Trying to compare separately major and minor versions in order to be
able to support more than one digit versions.

Also, parse non released versions with alpha, beta or rc suffixes.
Ignore the suffix and keep the numeric part.