### PR TITLE
Add EXECUTE command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ DISTNAME = $(EXTENSION)-$(DISTVERSION)
 REGRESS = plproxy_init plproxy_test plproxy_select plproxy_many \
      plproxy_errors plproxy_clustermap plproxy_dynamic_record \
      plproxy_encoding plproxy_split plproxy_target plproxy_alter \
-     plproxy_cancel
+     plproxy_cancel plproxy_execute
 REGRESS_OPTS = --dbname=regression --inputdir=test
 # pg9.1 ignores --dbname
 override CONTRIB_TESTDB := regression

--- a/doc/config.md
+++ b/doc/config.md
@@ -51,8 +51,9 @@ external source such as a configuration table.
 This is called when a new partition configuration needs to be loaded. 
 It should return connect strings to the partitions in the cluster.
 The connstrings should be returned in the correct order.  The total
-number of connstrings returned must be a power of 2.  If two or more
-connstrings are equal then they will use the same connection.
+number of connstrings returned must be a power of 2 unless hashing is
+disabled.  If two or more connstrings are equal then they will use
+the same connection.
 
 If the string `user=` does not appear in a connect string then
 `user=CURRENT_USER` will be appended to the connection string by PL/Proxy.  
@@ -126,6 +127,11 @@ or NULL then the parameter is disabled (a default value will be used).
 * `disable_binary`
 
   Do not use binary I/O for connections to this cluster.
+
+* `disable_hashing`
+
+  Disable mapping of hash values to partition numbers. Partition numbers can
+  still be used directly. Allows for non power-of-2 partition counts. 
 
 * `keepalive_idle`
 

--- a/doc/faq.md
+++ b/doc/faq.md
@@ -229,6 +229,10 @@ For example, if user needs to spread the load over 3 servers,
 the database can be split to 16 partitions and then 2 servers
 get 5 partitions and last one 6.
 
+If user wants to solve those issues on their own, the `disable_hashing`
+option delegates the responsibility of hash-value to partition mapping
+to the partitioning function.
+
 
 ## Partitioning
 

--- a/src/execute.c
+++ b/src/execute.c
@@ -991,6 +991,8 @@ tag_run_on_partitions(ProxyFunction *func, FunctionCallInfo fcinfo, int tag,
 	switch (func->run_type)
 	{
 		case R_HASH:
+			if (cluster->config.disable_hashing)
+				plproxy_error(func, "hash based partitioning is disabled");
 			tag_hash_partitions(func, fcinfo, tag, array_params, array_row);
 			break;
 		case R_ALL:
@@ -1004,7 +1006,10 @@ tag_run_on_partitions(ProxyFunction *func, FunctionCallInfo fcinfo, int tag,
 			tag_part(cluster, i, tag);
 			break;
 		case R_ANY:
-			i = random() & cluster->part_mask;
+			if (cluster->config.disable_hashing)
+				i = random() % cluster->part_count;
+			else
+				i = random() & cluster->part_mask;
 			tag_part(cluster, i, tag);
 			break;
 		default:

--- a/src/execute.c
+++ b/src/execute.c
@@ -62,6 +62,9 @@ static int geterrcode(void)
 }
 #endif
 
+/* Forward declarations */
+static void prepare_query_parameters(ProxyFunction *func, FunctionCallInfo fcinfo);
+
 /* some error happened */
 static void
 conn_error(ProxyFunction *func, ProxyConnection *conn, const char *desc)
@@ -182,7 +185,7 @@ send_query(ProxyFunction *func, ProxyConnection *conn,
 {
 	int			res;
 	struct timeval now;
-	ProxyQuery *q = func->remote_sql;
+	ProxyQuery *q = conn->remote_sql;
 	ProxyConfig *cf = &func->cur_cluster->config;
 	int			binary_result = 0;
 
@@ -192,6 +195,10 @@ send_query(ProxyFunction *func, ProxyConnection *conn,
 	tune_connection(func, conn);
 	if (conn->cur->tuning)
 		return;
+
+	/* If no query is specified, we are immediately done */
+	if (!q)
+		conn->cur->state = C_DONE;
 
 	/* use binary result only on same backend ver */
 	if (cf->disable_binary == 0 && conn->cur->same_ver)
@@ -1144,6 +1151,83 @@ prepare_and_tag_partitions(ProxyFunction *func, FunctionCallInfo fcinfo)
 	}
 }
 
+
+static char *
+extract_query_from_split(ProxyFunction* func, Datum query_array)
+{
+	ArrayType *arr = DatumGetArrayTypeP(query_array);
+	Datum	*queries;
+	bool	*nulls;
+	int		 nitems, i;
+	char 	*result = 0;
+
+	if (ARR_ELEMTYPE(arr) != TEXTOID)
+		plproxy_error(func, "Query array for EXECUTE must be of type text[]");
+
+	deconstruct_array(arr,
+					  TEXTOID, -1, false, 'i',
+					  &queries, &nulls, &nitems);
+
+	for (i = 0; i < nitems; i++)
+	{
+		if (nulls[i])
+			continue;
+
+		if (result)
+			plproxy_error(func, "All partitions must get at most one query");
+
+		result = TextDatumGetCString(queries[i]);
+	}
+
+	return result;
+}
+
+static void
+prepare_queries(ProxyFunction* func, FunctionCallInfo fcinfo)
+{
+	int part;
+	ProxyCluster   *cluster = func->cur_cluster;
+
+	if (func->is_execute)
+	{
+		/* Add the parameters to partitions */
+		for (part = 0; part < cluster->active_count; part++) {
+			char *query;
+			QueryBuffer* qb;
+			ProxyConnection* conn = cluster->active_list[part];
+
+			conn->remote_sql = 0;
+
+			if (!conn->run_tag)
+				continue;
+
+			if (PG_ARGISNULL(func->execute_arg))
+				continue;
+
+
+			if (IS_SPLIT_ARG(func, func->execute_arg))
+				query = extract_query_from_split(func, conn->split_params[func->execute_arg]);
+			else
+				query = text_to_cstring(PG_GETARG_TEXT_P(func->execute_arg));
+
+			if (query)
+			{
+				qb = plproxy_query_start(func, false);
+				plproxy_query_add_const(qb, query);
+				conn->remote_sql = plproxy_query_finish(qb);
+			}
+		}
+	}
+	else
+	{
+		for (part = 0; part < cluster->active_count; part++)
+			cluster->active_list[part]->remote_sql = func->remote_sql;
+
+		/* prepare the target query parameters */
+		prepare_query_parameters(func, fcinfo);
+	}
+}
+
 /*
  * Prepare parameters for the query.
  */
@@ -1152,6 +1236,8 @@ prepare_query_parameters(ProxyFunction *func, FunctionCallInfo fcinfo)
 {
 	int				i;
 	ProxyCluster   *cluster = func->cur_cluster;
+	/* Parameters for EXECUTE not supported yet */
+	Assert(!func->is_execute);
 
 	for (i = 0; i < func->remote_sql->arg_count; i++)
 	{
@@ -1274,8 +1360,8 @@ plproxy_exec(ProxyFunction *func, FunctionCallInfo fcinfo)
 		/* tag the partitions and prepare per-partition parameters */
 		prepare_and_tag_partitions(func, fcinfo);
 
-		/* prepare the target query parameters */
-		prepare_query_parameters(func, fcinfo);
+		/* prepare target queries */
+		prepare_queries(func, fcinfo);
 
 		remote_execute(func);
 

--- a/src/function.c
+++ b/src/function.c
@@ -155,12 +155,18 @@ bool
 plproxy_execute_ident(ProxyFunction *func, const char *ident)
 {
 	int		argindex;
+	ProxyType* type;
 
 	if ((argindex = plproxy_get_parameter_index(func, ident)) < 0)
 		return false;
 
+	type = func->arg_types[argindex];
+	if ((type->is_array ? type->elem_type_oid : type->type_oid) != TEXTOID)
+		plproxy_error(func, "EXECUTE parameter is not text: %s", ident);
+
 	func->is_execute = true;
 	func->execute_arg = argindex;
+	func->execute_is_array = type->is_array;
 
 	return true;
 }

--- a/src/function.c
+++ b/src/function.c
@@ -150,6 +150,21 @@ plproxy_split_all_arrays(ProxyFunction *func)
 	}
 }
 
+/* Add execute by identifier */
+bool
+plproxy_execute_ident(ProxyFunction *func, const char *ident)
+{
+	int		argindex;
+
+	if ((argindex = plproxy_get_parameter_index(func, ident)) < 0)
+		return false;
+
+	func->is_execute = true;
+	func->execute_arg = argindex;
+
+	return true;
+}
+
 /* Initialize PL/Proxy function cache */
 void
 plproxy_function_cache_init(void)

--- a/src/parser.y
+++ b/src/parser.y
@@ -269,6 +269,9 @@ void plproxy_run_parser(ProxyFunction *func, const char *body, int len)
 	if (got_execute && got_target)
 		yyerror("EXECUTE cannot be used with TARGET");
 
+	if (got_execute && xfunc->execute_is_array && !IS_SPLIT_ARG(xfunc, xfunc->execute_arg))
+		yyerror("EXECUTE argument is an array, but is not split");
+
 	/* release scanner resources */
 	plproxy_yylex_destroy();
 

--- a/src/parser.y
+++ b/src/parser.y
@@ -33,7 +33,7 @@
 static ProxyFunction *xfunc;
 
 /* remember what happened */
-static int got_run, got_cluster, got_connect, got_split, got_target;
+static int got_run, got_cluster, got_connect, got_split, got_target, got_execute;
 
 static QueryBuffer *cluster_sql;
 static QueryBuffer *select_sql;
@@ -46,7 +46,7 @@ static QueryBuffer *cur_sql;
 /* keep the resetting code together with variables */
 static void reset_parser_vars(void)
 {
-	got_run = got_cluster = got_connect = got_split = got_target = 0;
+	got_run = got_cluster = got_connect = got_split = got_target = got_execute = 0;
 	cur_sql = select_sql = cluster_sql = hash_sql = connect_sql = NULL;
 	xfunc = NULL;
 }
@@ -64,7 +64,7 @@ static void reset_parser_vars(void)
 
 %token <str> CONNECT CLUSTER RUN ON ALL ANY SELECT
 %token <str> IDENT NUMBER FNCALL SPLIT STRING
-%token <str> SQLIDENT SQLPART TARGET
+%token <str> SQLIDENT SQLPART TARGET EXECUTE
 
 %union
 {
@@ -75,7 +75,7 @@ static void reset_parser_vars(void)
 
 body: | body stmt ;
 
-stmt: cluster_stmt | split_stmt | run_stmt | select_stmt | connect_stmt | target_stmt;
+stmt: cluster_stmt | split_stmt | run_stmt | select_stmt | connect_stmt | target_stmt | execute_stmt;
 
 connect_stmt: CONNECT connect_spec ';'	{
 					if (got_connect)
@@ -150,6 +150,15 @@ split_param: IDENT {
 				if (!plproxy_split_add_ident(xfunc, $1))
 					yyerror("invalid argument reference: %s", $1);
 			}
+
+execute_stmt: EXECUTE execute_direct ';' { 	if (got_execute)
+												yyerror("Only one EXECUTE statement allowed");
+											got_execute = 1; }
+			;
+
+execute_direct: IDENT { if (!plproxy_execute_ident(xfunc, $1))
+							yyerror("invalid argument reference: %s", $1);
+					  }
 
 run_stmt: RUN ON run_spec ';'	{ if (got_run)
 									yyerror("Only one RUN statement allowed");
@@ -253,6 +262,12 @@ void plproxy_run_parser(ProxyFunction *func, const char *body, int len)
 
 	if (select_sql && got_target)
 		yyerror("TARGET cannot be used with SELECT");
+
+	if (select_sql && got_execute)
+		yyerror("EXECUTE cannot be used with SELECT");
+
+	if (got_execute && got_target)
+		yyerror("EXECUTE cannot be used with TARGET");
 
 	/* release scanner resources */
 	plproxy_yylex_destroy();

--- a/src/plproxy.h
+++ b/src/plproxy.h
@@ -188,6 +188,7 @@ typedef struct ProxyConfig
 	int			query_timeout;			/* How long query may take (secs) */
 	int			connection_lifetime;	/* How long the connection may live (secs) */
 	int			disable_binary;			/* Avoid binary I/O */
+	int			disable_hashing;		/* Disable hashing to support non power-of-2 partitions */
 	/* keepalive parameters */
 	int			keepidle;
 	int			keepintvl;

--- a/src/plproxy.h
+++ b/src/plproxy.h
@@ -418,6 +418,7 @@ typedef struct ProxyFunction
 
 	bool	is_execute;
 	int		execute_arg;
+	bool	execute_is_array;
 
 	/*
 	 * calculated data

--- a/src/scanner.l
+++ b/src/scanner.l
@@ -184,6 +184,7 @@ all			{ return ALL; }
 any			{ return ANY; }
 split		{ return SPLIT; }
 target		{ return TARGET; }
+execute     { return EXECUTE; }
 select			{ BEGIN(sql); yylval.str = yytext; return SELECT; }
 
 	/* function call */

--- a/test/expected/plproxy_encoding.out
+++ b/test/expected/plproxy_encoding.out
@@ -12,7 +12,7 @@ set client_encoding = 'utf8';
 set client_min_messages = 'warning';
 drop database if exists test_enc_proxy;
 drop database if exists test_enc_part;
-create database test_enc_proxy with encoding 'euc_jp' template template0;
+create database test_enc_proxy with encoding 'euc_jp' lc_collate 'C' lc_ctype 'C' template template0;
 create database test_enc_part with encoding 'utf-8' template template0;
 -- initialize proxy db
 \c test_enc_proxy
@@ -119,7 +119,7 @@ set client_min_messages = 'warning';
 drop database if exists test_enc_proxy;
 drop database if exists test_enc_part;
 create database test_enc_proxy with encoding 'utf-8' template template0;
-create database test_enc_part with encoding 'euc_jp' template template0;
+create database test_enc_part with encoding 'euc_jp' lc_collate 'C' lc_ctype 'C' template template0;
 -- initialize proxy db
 \c test_enc_proxy
 set client_min_messages = 'fatal';

--- a/test/expected/plproxy_execute.out
+++ b/test/expected/plproxy_execute.out
@@ -1,0 +1,161 @@
+\c regression
+create or replace function plproxy.get_cluster_partitions(cluster_name text)
+returns setof text as $$
+begin
+    if cluster_name = 'testcluster' then
+        return next 'host=127.0.0.1 dbname=test_part0';
+        return next 'host=127.0.0.1 dbname=test_part1';
+        return next 'host=127.0.0.1 dbname=test_part2';
+        return next 'host=127.0.0.1 dbname=test_part3';
+        return;
+    end if;
+    raise exception 'no such cluster: %', cluster_name;
+end; $$ language plpgsql;
+CREATE TABLE my_table (dbname text, i int);
+-- same query on all nodes
+CREATE OR REPLACE FUNCTION test_execute_single_on_all(query text) RETURNS SETOF my_table AS $$
+cluster 'testcluster';
+run on all;
+execute query;
+$$ LANGUAGE plproxy;
+SELECT * FROM test_execute_single_on_all('SELECT current_database() AS dbname, 1 AS i') ORDER BY dbname;
+   dbname   | i 
+------------+---
+ test_part0 | 1
+ test_part1 | 1
+ test_part2 | 1
+ test_part3 | 1
+(4 rows)
+
+-- Null means nothing gets executed
+SELECT * FROM test_execute_single_on_all(NULL) ORDER BY dbname;
+ dbname | i 
+--------+---
+(0 rows)
+
+-- Wrong datatype is validated
+CREATE OR REPLACE FUNCTION test_execute_wrong_datatype(query int) RETURNS SETOF my_table AS $$
+cluster 'testcluster';
+execute query;
+$$ LANGUAGE plproxy;
+ERROR:  PL/Proxy function public.test_execute_wrong_datatype(1): EXECUTE parameter is not text: query
+CREATE OR REPLACE FUNCTION test_execute_wrong_datatype(query int[]) RETURNS SETOF my_table AS $$
+cluster 'testcluster';
+execute query;
+$$ LANGUAGE plproxy;
+ERROR:  PL/Proxy function public.test_execute_wrong_datatype(1): EXECUTE parameter is not text: query
+-- Same query on specific nodes
+CREATE OR REPLACE FUNCTION test_execute_single_on_some(nodes int[], query text) RETURNS SETOF my_table AS $$
+cluster 'testcluster';
+split nodes;
+run on nodes;
+execute query;
+$$ LANGUAGE plproxy;
+SELECT * FROM test_execute_single_on_some(array[0,2], 'SELECT current_database() AS dbname, 1 AS i');
+   dbname   | i 
+------------+---
+ test_part0 | 1
+ test_part2 | 1
+(2 rows)
+
+-- All queries on all nodes. Maximum of 1 query for now.
+CREATE OR REPLACE FUNCTION test_execute_multiple_on_all(queries text[]) RETURNS SETOF my_table AS $$
+cluster 'testcluster';
+split queries;
+run on all;
+execute queries;
+$$ LANGUAGE plproxy;
+SELECT * FROM test_execute_multiple_on_all(array[
+	'SELECT current_database() AS dbname, 1 AS i',
+	'SELECT current_database() AS dbname, 2 AS i'
+]);
+ERROR:  PL/Proxy function public.test_execute_multiple_on_all(1): All partitions must get at most one query
+SELECT * FROM test_execute_multiple_on_all(array[
+	'SELECT current_database() AS dbname, 1 AS i',
+	NULL
+]);
+   dbname   | i 
+------------+---
+ test_part0 | 1
+ test_part1 | 1
+ test_part2 | 1
+ test_part3 | 1
+(4 rows)
+
+-- Specify one query per node
+CREATE OR REPLACE FUNCTION test_execute_multiple_on_specific(queries text[], nodes int[]) RETURNS SETOF my_table AS $$
+cluster 'testcluster';
+split nodes, queries;
+run on nodes;
+execute queries;
+$$ LANGUAGE plproxy;
+SELECT * FROM test_execute_multiple_on_specific(array[
+	'SELECT current_database() AS dbname, 1 AS i',
+	'SELECT current_database() AS dbname, 2 AS i'
+], array[3,0]);
+   dbname   | i 
+------------+---
+ test_part3 | 1
+ test_part0 | 2
+(2 rows)
+
+-- Null queries get skipped 
+SELECT * FROM test_execute_multiple_on_specific(array[
+	NULL,
+	'SELECT current_database() AS dbname, 1 AS i',
+	'SELECT current_database() AS dbname, 2 AS i',
+	NULL
+], array[0,1,2,3]);
+   dbname   | i 
+------------+---
+ test_part1 | 1
+ test_part2 | 2
+(2 rows)
+
+-- Array of queries not split is validated
+CREATE OR REPLACE FUNCTION test_execute_multiple_no_split(queries text[], nodes int[]) RETURNS SETOF my_table AS $$
+cluster 'testcluster';
+split nodes;
+run on nodes;
+execute queries;
+$$ LANGUAGE plproxy;
+ERROR:  PL/Proxy function public.test_execute_multiple_no_split(2): Compile error at line 6: EXECUTE argument is an array, but is not split
+-- Split queries on single node works when only one query
+CREATE OR REPLACE FUNCTION test_execute_multiple_on_single(queries text[], node int) RETURNS SETOF my_table AS $$
+cluster 'testcluster';
+split queries;
+run on node;
+execute queries;
+$$ LANGUAGE plproxy;
+SELECT * FROM test_execute_multiple_on_single(array[
+	'SELECT current_database() AS dbname, 1 AS i',
+	'SELECT current_database() AS dbname, 2 AS i'
+], 3);
+ERROR:  PL/Proxy function public.test_execute_multiple_on_single(2): All partitions must get at most one query
+SELECT * FROM test_execute_multiple_on_single(array[
+	'SELECT current_database() AS dbname, 1 AS i',
+	NULL
+], 3);
+   dbname   | i 
+------------+---
+ test_part3 | 1
+(1 row)
+
+-- No queries means no results
+SELECT * FROM test_execute_multiple_on_single(array[]::text[], 3);
+ dbname | i 
+--------+---
+(0 rows)
+
+-- Run one query on specific node
+CREATE OR REPLACE FUNCTION test_execute_single_on_single(node int, query text) RETURNS SETOF my_table AS $$
+cluster 'testcluster';
+run on node;
+execute query;
+$$ LANGUAGE plproxy;
+SELECT * FROM test_execute_single_on_single(0, 'SELECT current_database() AS dbname, 1 AS i');
+   dbname   | i 
+------------+---
+ test_part0 | 1
+(1 row)
+

--- a/test/sql/plproxy_encoding.sql
+++ b/test/sql/plproxy_encoding.sql
@@ -17,7 +17,7 @@ set client_encoding = 'utf8';
 set client_min_messages = 'warning';
 drop database if exists test_enc_proxy;
 drop database if exists test_enc_part;
-create database test_enc_proxy with encoding 'euc_jp' template template0;
+create database test_enc_proxy with encoding 'euc_jp' lc_collate 'C' lc_ctype 'C' template template0;
 create database test_enc_part with encoding 'utf-8' template template0;
 
 -- initialize proxy db
@@ -90,7 +90,7 @@ set client_min_messages = 'warning';
 drop database if exists test_enc_proxy;
 drop database if exists test_enc_part;
 create database test_enc_proxy with encoding 'utf-8' template template0;
-create database test_enc_part with encoding 'euc_jp' template template0;
+create database test_enc_part with encoding 'euc_jp' lc_collate 'C' lc_ctype 'C' template template0;
 
 -- initialize proxy db
 \c test_enc_proxy

--- a/test/sql/plproxy_execute.sql
+++ b/test/sql/plproxy_execute.sql
@@ -1,0 +1,123 @@
+\c regression
+
+create or replace function plproxy.get_cluster_partitions(cluster_name text)
+returns setof text as $$
+begin
+    if cluster_name = 'testcluster' then
+        return next 'host=127.0.0.1 dbname=test_part0';
+        return next 'host=127.0.0.1 dbname=test_part1';
+        return next 'host=127.0.0.1 dbname=test_part2';
+        return next 'host=127.0.0.1 dbname=test_part3';
+        return;
+    end if;
+    raise exception 'no such cluster: %', cluster_name;
+end; $$ language plpgsql;
+
+CREATE TABLE my_table (dbname text, i int);
+
+-- same query on all nodes
+CREATE OR REPLACE FUNCTION test_execute_single_on_all(query text) RETURNS SETOF my_table AS $$
+cluster 'testcluster';
+run on all;
+execute query;
+$$ LANGUAGE plproxy;
+
+SELECT * FROM test_execute_single_on_all('SELECT current_database() AS dbname, 1 AS i') ORDER BY dbname;
+-- Null means nothing gets executed
+SELECT * FROM test_execute_single_on_all(NULL) ORDER BY dbname;
+
+-- Wrong datatype is validated
+CREATE OR REPLACE FUNCTION test_execute_wrong_datatype(query int) RETURNS SETOF my_table AS $$
+cluster 'testcluster';
+execute query;
+$$ LANGUAGE plproxy;
+
+CREATE OR REPLACE FUNCTION test_execute_wrong_datatype(query int[]) RETURNS SETOF my_table AS $$
+cluster 'testcluster';
+execute query;
+$$ LANGUAGE plproxy;
+
+-- Same query on specific nodes
+CREATE OR REPLACE FUNCTION test_execute_single_on_some(nodes int[], query text) RETURNS SETOF my_table AS $$
+cluster 'testcluster';
+split nodes;
+run on nodes;
+execute query;
+$$ LANGUAGE plproxy;
+
+SELECT * FROM test_execute_single_on_some(array[0,2], 'SELECT current_database() AS dbname, 1 AS i');
+
+-- All queries on all nodes. Maximum of 1 query for now.
+CREATE OR REPLACE FUNCTION test_execute_multiple_on_all(queries text[]) RETURNS SETOF my_table AS $$
+cluster 'testcluster';
+split queries;
+run on all;
+execute queries;
+$$ LANGUAGE plproxy;
+
+SELECT * FROM test_execute_multiple_on_all(array[
+	'SELECT current_database() AS dbname, 1 AS i',
+	'SELECT current_database() AS dbname, 2 AS i'
+]);
+SELECT * FROM test_execute_multiple_on_all(array[
+	'SELECT current_database() AS dbname, 1 AS i',
+	NULL
+]);
+
+-- Specify one query per node
+CREATE OR REPLACE FUNCTION test_execute_multiple_on_specific(queries text[], nodes int[]) RETURNS SETOF my_table AS $$
+cluster 'testcluster';
+split nodes, queries;
+run on nodes;
+execute queries;
+$$ LANGUAGE plproxy;
+
+SELECT * FROM test_execute_multiple_on_specific(array[
+	'SELECT current_database() AS dbname, 1 AS i',
+	'SELECT current_database() AS dbname, 2 AS i'
+], array[3,0]);
+-- Null queries get skipped 
+SELECT * FROM test_execute_multiple_on_specific(array[
+	NULL,
+	'SELECT current_database() AS dbname, 1 AS i',
+	'SELECT current_database() AS dbname, 2 AS i',
+	NULL
+], array[0,1,2,3]);
+
+-- Array of queries not split is validated
+CREATE OR REPLACE FUNCTION test_execute_multiple_no_split(queries text[], nodes int[]) RETURNS SETOF my_table AS $$
+cluster 'testcluster';
+split nodes;
+run on nodes;
+execute queries;
+$$ LANGUAGE plproxy;
+
+-- Split queries on single node works when only one query
+CREATE OR REPLACE FUNCTION test_execute_multiple_on_single(queries text[], node int) RETURNS SETOF my_table AS $$
+cluster 'testcluster';
+split queries;
+run on node;
+execute queries;
+$$ LANGUAGE plproxy;
+
+SELECT * FROM test_execute_multiple_on_single(array[
+	'SELECT current_database() AS dbname, 1 AS i',
+	'SELECT current_database() AS dbname, 2 AS i'
+], 3);
+
+SELECT * FROM test_execute_multiple_on_single(array[
+	'SELECT current_database() AS dbname, 1 AS i',
+	NULL
+], 3);
+
+-- No queries means no results
+SELECT * FROM test_execute_multiple_on_single(array[]::text[], 3);
+
+-- Run one query on specific node
+CREATE OR REPLACE FUNCTION test_execute_single_on_single(node int, query text) RETURNS SETOF my_table AS $$
+cluster 'testcluster';
+run on node;
+execute query;
+$$ LANGUAGE plproxy;
+
+SELECT * FROM test_execute_single_on_single(0, 'SELECT current_database() AS dbname, 1 AS i');


### PR DESCRIPTION
Currently PostgreSQL parallel execution does not work when query is run with plpgsql `RETURN QUERY`. To work around this it would be good to be able to send dynamically generated SQL from plproxy to remote servers. To enable this I propose to add a `EXECUTE` command to plproxy language. It fetches query from the argument list and sends to servers. Interacts nicely with `RUN ON` and `SPLIT`.

Example:

    CREATE FUNCTION parallel_execute(query text) RETURNS SETOF record AS $$
        CLUSTER 'mycluster';
        RUN ON ALL;
        EXECUTE query;
    $$ LANGUAGE plproxy;
    
    SELECT SUM(psum) total_sum
        FROM parallel_execute('SELECT SUM(x) psum FROM big_table') partial_sums(psum int8);

Somewhat unrelatedly, optionally lift power-of-2 restriction from number of partitions when `disable_hashing` is specified. Responsibility of mapping to partition numbers is then delegated to the user. Plproxy only error checks the resulting partition number.
