### PR TITLE
Adapt to PostgreSQL changes

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -164,9 +164,7 @@ plproxy_cluster_cache_init(void)
 
 	cluster_mem = AllocSetContextCreate(TopMemoryContext,
 										"PL/Proxy cluster context",
-										ALLOCSET_SMALL_MINSIZE,
-										ALLOCSET_SMALL_INITSIZE,
-										ALLOCSET_SMALL_MAXSIZE);
+										ALLOCSET_SMALL_SIZES);
 	aatree_init(&cluster_tree, cluster_name_cmp, NULL);
 	aatree_init(&fake_cluster_tree, cluster_name_cmp, NULL);
 }

--- a/src/function.c
+++ b/src/function.c
@@ -235,9 +235,7 @@ fn_new(HeapTuple proc_tuple)
 
 	f_ctx = AllocSetContextCreate(TopMemoryContext,
 								  "PL/Proxy function context",
-								  ALLOCSET_SMALL_MINSIZE,
-								  ALLOCSET_SMALL_INITSIZE,
-								  ALLOCSET_SMALL_MAXSIZE);
+								  ALLOCSET_SMALL_SIZES);
 
 	old_ctx = MemoryContextSwitchTo(f_ctx);
 

--- a/src/plproxy.h
+++ b/src/plproxy.h
@@ -144,6 +144,14 @@
 #endif
 
 /*
+ * backwards compatibility with v10.
+ */
+
+#if PG_VERSION_NUM >= 110000
+#define ACL_KIND_FOREIGN_SERVER OBJECT_FOREIGN_SERVER
+#endif
+
+/*
  * Determine if this argument is to SPLIT
  */
 #define IS_SPLIT_ARG(func, arg)	((func)->split_args && (func)->split_args[arg])


### PR DESCRIPTION
I noticed that PL/Proxy doesn't build with current PostgreSQL head.

I have fixed these two problems:

- Commit 8b9e9644dc6a9bd4b7a97950e6212f63880cf18b replaced `ACL_KIND_FOREIGN_SERVER` with `OBJECT_FOREIGN_SERVER`

- Commit 9fa6f00b1308dd10da4eca2f31ccbfc7b35bb461 removed the 5-argument version of `AllocSetContextCreate`

Commit 37a795a60b4f4b1def11c615525ec5e0e9449e05 introduced `TYPEFUNC_COMPOSITE_DOMAIN`, but I don't know how to handle that.