### PR TITLE
tests: drop "create language plpgsql"

### DIFF
--- a/test/expected/plproxy_encoding.out
+++ b/test/expected/plproxy_encoding.out
@@ -17,8 +17,6 @@ create database test_enc_part with encoding 'utf-8' template template0;
 -- initialize proxy db
 \c test_enc_proxy
 set client_encoding = 'utf-8';
-set client_min_messages = 'fatal';
-create language plpgsql;
 set client_min_messages = 'warning';
 \set ECHO none
 create schema plproxy;
@@ -43,8 +41,6 @@ create function test_encoding3(text) returns setof intl_data as $$
 $$ language plproxy;
 -- initialize part db
 \c test_enc_part
-set client_min_messages = 'fatal';
-create language plpgsql;
 set client_min_messages = 'warning';
 set client_encoding = 'utf8';
 create table intl_data (id int4, "コラム" text);
@@ -122,8 +118,6 @@ create database test_enc_proxy with encoding 'utf-8' template template0;
 create database test_enc_part with encoding 'euc_jp' template template0;
 -- initialize proxy db
 \c test_enc_proxy
-set client_min_messages = 'fatal';
-create language plpgsql;
 set client_min_messages = 'warning';
 \set ECHO none
 set client_encoding = 'utf8';
@@ -149,8 +143,6 @@ create function test_encoding3(text) returns setof intl_data as $$
 $$ language plproxy;
 -- initialize part db
 \c test_enc_part
-set client_min_messages = 'fatal';
-create language plpgsql;
 set client_min_messages = 'warning';
 set client_encoding = 'utf8';
 create table intl_data (id int4, "コラム" text);

--- a/test/sql/plproxy_encoding.sql
+++ b/test/sql/plproxy_encoding.sql
@@ -23,8 +23,6 @@ create database test_enc_part with encoding 'utf-8' template template0;
 -- initialize proxy db
 \c test_enc_proxy
 set client_encoding = 'utf-8';
-set client_min_messages = 'fatal';
-create language plpgsql;
 set client_min_messages = 'warning';
 \set ECHO none
 \i sql/plproxy.sql
@@ -52,8 +50,6 @@ create function test_encoding3(text) returns setof intl_data as $$
 $$ language plproxy;
 -- initialize part db
 \c test_enc_part
-set client_min_messages = 'fatal';
-create language plpgsql;
 set client_min_messages = 'warning';
 set client_encoding = 'utf8';
 create table intl_data (id int4, "コラム" text);
@@ -94,8 +90,6 @@ create database test_enc_part with encoding 'euc_jp' template template0;
 
 -- initialize proxy db
 \c test_enc_proxy
-set client_min_messages = 'fatal';
-create language plpgsql;
 set client_min_messages = 'warning';
 \set ECHO none
 \i sql/plproxy.sql
@@ -125,8 +119,6 @@ $$ language plproxy;
 
 -- initialize part db
 \c test_enc_part
-set client_min_messages = 'fatal';
-create language plpgsql;
 set client_min_messages = 'warning';
 set client_encoding = 'utf8';
 create table intl_data (id int4, "コラム" text);

--- a/test/sql/plproxy_init.sql
+++ b/test/sql/plproxy_init.sql
@@ -5,10 +5,6 @@ set client_min_messages = 'warning';
 
 \i sql/plproxy.sql
 
-set client_min_messages = 'fatal';
-create language plpgsql;
-set client_min_messages = 'warning';
-
 -- create cluster info functions
 create schema plproxy;
 create or replace function plproxy.get_cluster_version(cluster_name text)
@@ -64,19 +60,3 @@ create database test_part3;
 
 drop database if exists test_enc_proxy;
 drop database if exists test_enc_part;
-
-\c test_part
-set client_min_messages = 'fatal';
-create language plpgsql;
-\c test_part0
-set client_min_messages = 'fatal';
-create language plpgsql;
-\c test_part1
-set client_min_messages = 'fatal';
-create language plpgsql;
-\c test_part2
-set client_min_messages = 'fatal';
-create language plpgsql;
-\c test_part3
-set client_min_messages = 'fatal';
-create language plpgsql;


### PR DESCRIPTION
Recent PostgreSQL minors (11.2 and friends) disallow setting
client_min_messages higher than 'error', so suppressing errors that way
does not work anymore. Instead, drop the "create language plpgsql" code
as plpgsql is preinstalled by default since 9.1.

Context: https://git.postgresql.org/gitweb/?p=postgresql.git;a=commitdiff;h=7b08b4a8a