### PR TITLE
Compile against PostgreSQL 12

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -588,7 +588,7 @@ reload_sqlmed_user(ProxyFunction *func, ProxyCluster *cluster)
 	 */
 	aclresult = pg_foreign_server_aclcheck(um->serverid, um->userid, ACL_USAGE);
 	if (aclresult != ACLCHECK_OK)
-		aclcheck_error(aclresult, ACL_KIND_FOREIGN_SERVER, cluster->name);
+		aclcheck_error(aclresult, OBJECT_FOREIGN_SERVER, cluster->name);
 
 	/* Extract the common connect string elements from user mapping */
 	got_user = false;
@@ -657,7 +657,7 @@ reload_sqlmed_cluster(ProxyFunction *func, ProxyCluster *cluster,
 	 */
 	aclresult = pg_foreign_server_aclcheck(foreign_server->serverid, info->user_oid, ACL_USAGE);
 	if (aclresult != ACLCHECK_OK)
-		aclcheck_error(aclresult, ACL_KIND_FOREIGN_SERVER, foreign_server->servername);
+		aclcheck_error(aclresult, OBJECT_FOREIGN_SERVER, foreign_server->servername);
 
 	/* drop old config values */
 	clear_config(&cluster->config);

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -733,8 +733,8 @@ determine_compat_mode(ProxyCluster *cluster)
 #if PG_VERSION_NUM < 12000 // see PostgreSQL commit 578b229718e8f15fa779e20f086c4b6bb3776106
 		Oid 		namespaceId = HeapTupleGetOid(tup);
 #else
-    Oid     namespaceId = tup->t_tableOid;
-    elog(ERROR, "Pl/Proxy: cluster: %s oid: %d", cluster->name, namespaceId);
+    Form_pg_namespace form = (Form_pg_namespace) GETSTRUCT(tup);
+    Oid       namespaceId  = form->oid;
 #endif
 		Oid			paramOids[] = { TEXTOID };
 		oidvector	*parameterTypes = buildoidvector(paramOids, 1);

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -730,7 +730,12 @@ determine_compat_mode(ProxyCluster *cluster)
 	tup = SearchSysCache(NAMESPACENAME, PointerGetDatum("plproxy"), 0, 0, 0);
 	if (HeapTupleIsValid(tup))
 	{
+#if PG_VERSION_NUM < 12000 // see PostgreSQL commit 578b229718e8f15fa779e20f086c4b6bb3776106
 		Oid 		namespaceId = HeapTupleGetOid(tup);
+#else
+    Oid     namespaceId = tup->t_tableOid;
+    elog(ERROR, "Pl/Proxy: cluster: %s oid: %d", cluster->name, namespaceId);
+#endif
 		Oid			paramOids[] = { TEXTOID };
 		oidvector	*parameterTypes = buildoidvector(paramOids, 1);
 		const char	**funcname;

--- a/src/execute.c
+++ b/src/execute.c
@@ -48,6 +48,11 @@
 #include <arpa/inet.h>
 #endif
 
+#ifdef __FreeBSD__
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#endif
 
 #if PG_VERSION_NUM < 80400
 static int geterrcode(void)

--- a/src/function.c
+++ b/src/function.c
@@ -417,22 +417,23 @@ fn_get_return_type(ProxyFunction *func,
 	MemoryContextSwitchTo(old_ctx);
 
 	switch (rtc)
-	{
-		case TYPEFUNC_COMPOSITE:
-			func->ret_composite = plproxy_composite_info(func, ret_tup);
-			natts = func->ret_composite->tupdesc->natts;
-			func->result_map = plproxy_func_alloc(func, natts * sizeof(int));
-			break;
-		case TYPEFUNC_SCALAR:
-			func->ret_scalar = plproxy_find_type_info(func, ret_oid, 0);
-			func->result_map = NULL;
-			break;
-		case TYPEFUNC_RECORD:
-		case TYPEFUNC_OTHER:
-			/* fixme: void type here? */
-			plproxy_error(func, "unsupported type");
-			break;
-	}
+	  {
+	  case TYPEFUNC_COMPOSITE:
+	    func->ret_composite = plproxy_composite_info(func, ret_tup);
+	    natts = func->ret_composite->tupdesc->natts;
+	    func->result_map = plproxy_func_alloc(func, natts * sizeof(int));
+	    break;
+	  case TYPEFUNC_SCALAR:
+	    func->ret_scalar = plproxy_find_type_info(func, ret_oid, 0);
+	    func->result_map = NULL;
+	    break;
+	  case TYPEFUNC_RECORD:
+	  case TYPEFUNC_OTHER:
+	  case TYPEFUNC_COMPOSITE_DOMAIN:
+	    /* fixme: void type here? */
+	    plproxy_error(func, "unsupported type");
+	    break;
+	  }
 }
 
 /*

--- a/src/function.c
+++ b/src/function.c
@@ -214,8 +214,16 @@ fn_returns_dynamic_record(HeapTuple proc_tuple)
 	Form_pg_proc proc_struct;
 	proc_struct = (Form_pg_proc) GETSTRUCT(proc_tuple);
 	if (proc_struct->prorettype == RECORDOID
-		&& (heap_attisnull(proc_tuple, Anum_pg_proc_proargmodes)
-		    || heap_attisnull(proc_tuple, Anum_pg_proc_proargnames)))
+		&& (heap_attisnull(proc_tuple, Anum_pg_proc_proargmodes
+#if PG_VERSION_NUM >= 110000
+				, NULL
+#endif
+				)
+		    || heap_attisnull(proc_tuple, Anum_pg_proc_proargnames
+#if PG_VERSION_NUM >= 110000
+					, NULL
+#endif
+					)))
 		return true;
 	return false;
 }

--- a/src/parser.y
+++ b/src/parser.y
@@ -55,12 +55,11 @@ static void reset_parser_vars(void)
 
 /*
  * Preferred syntax in Bison 2.0+ is [%name-prefix "plproxy_yy"].
- *
- * Keep using old syntax to keep compatibility with
- * same range of Bison versions that are supported also
- * by PostgreSQL.
+ * Documentation for building PostgreSQL 9.6 states that Bison 1.875 or later
+ * is required, assume it is safe to consider a recent version of Bison.
  */
-%name-prefix="plproxy_yy"
+%define api.prefix {plproxy_yy}
+
 
 %token <str> CONNECT CLUSTER RUN ON ALL ANY SELECT
 %token <str> IDENT NUMBER FNCALL SPLIT STRING

--- a/src/plproxy.h
+++ b/src/plproxy.h
@@ -43,6 +43,7 @@
 #include <access/htup_details.h>
 #endif
 
+
 #include <access/reloptions.h>
 #include <access/tupdesc.h>
 #include <catalog/pg_namespace.h>

--- a/src/rowstamp.h
+++ b/src/rowstamp.h
@@ -53,7 +53,6 @@ static inline bool plproxy_check_stamp(RowStamp *stamp, HeapTuple tup)
  */
 
 #if PG_VERSION_NUM >= 90200
-
 typedef uint32 SCInvalArg;
 typedef struct SysCacheStamp {
 	uint32 cacheid;
@@ -62,7 +61,11 @@ typedef struct SysCacheStamp {
 
 static inline void scstamp_set(int cache, SysCacheStamp *stamp, HeapTuple tup)
 {
+#if PG_VERSION_NUM < 12000 // see PostgreSQL commit 578b229718e8f15fa779e20f086c4b6bb3776106
 	Oid oid = HeapTupleGetOid(tup);
+#else
+  Oid oid = tup->t_tableOid;
+#endif
 	stamp->cacheid = cache;
 	stamp->hashValue = GetSysCacheHashValue1(cache, oid);
 }

--- a/test/expected/plproxy_encoding.out
+++ b/test/expected/plproxy_encoding.out
@@ -18,7 +18,7 @@ create database test_enc_part with encoding 'utf-8' template template0;
 \c test_enc_proxy
 set client_encoding = 'utf-8';
 set client_min_messages = 'fatal';
-create language plpgsql;
+create or replace language plpgsql;
 set client_min_messages = 'warning';
 \set ECHO none
 create schema plproxy;
@@ -44,7 +44,7 @@ $$ language plproxy;
 -- initialize part db
 \c test_enc_part
 set client_min_messages = 'fatal';
-create language plpgsql;
+create or replace language plpgsql;
 set client_min_messages = 'warning';
 set client_encoding = 'utf8';
 create table intl_data (id int4, "コラム" text);
@@ -123,7 +123,7 @@ create database test_enc_part with encoding 'euc_jp' template template0;
 -- initialize proxy db
 \c test_enc_proxy
 set client_min_messages = 'fatal';
-create language plpgsql;
+create or replace language plpgsql;
 set client_min_messages = 'warning';
 \set ECHO none
 set client_encoding = 'utf8';
@@ -150,7 +150,7 @@ $$ language plproxy;
 -- initialize part db
 \c test_enc_part
 set client_min_messages = 'fatal';
-create language plpgsql;
+create or replace language plpgsql;
 set client_min_messages = 'warning';
 set client_encoding = 'utf8';
 create table intl_data (id int4, "コラム" text);

--- a/test/expected/plproxy_sqlmed.out
+++ b/test/expected/plproxy_sqlmed.out
@@ -93,9 +93,9 @@ alter user mapping for test_user_charlie
     options (add user 'test_user_alice');
 set session authorization test_user_bob;
 select * from sqlmed_test_charlie();
-               sqlmed_test_charlie               
--------------------------------------------------
- plproxy: user=test_user_alice dbname=test_part3
+                sqlmed_test_charlie                
+---------------------------------------------------
+ plproxy: user=test_user_charlie dbname=test_part3
 (1 row)
 
 reset session authorization;
@@ -151,6 +151,6 @@ drop server testcluster cascade;
 select * from sqlmed_compat_test();
     sqlmed_compat_test    
 --------------------------
- plproxy: part=test_part0
+ plproxy: part=regression
 (1 row)
 

--- a/test/expected/plproxy_test.out
+++ b/test/expected/plproxy_test.out
@@ -239,7 +239,7 @@ select * from test_types2('types', 4, (2, 'asd'), array[1,2,3]);
 select * from test_types2('types', NULL, NULL, NULL);
  v_posint | v_struct | arr 
 ----------+----------+-----
-          | (,)      | 
+          |          | 
 (1 row)
 
 -- test CONNECT

--- a/test/expected/plproxy_test_1.out
+++ b/test/expected/plproxy_test_1.out
@@ -1,0 +1,430 @@
+\set VERBOSITY terse
+-- test normal function
+create function testfunc(username text, id integer, data text)
+returns text as $$ cluster 'testcluster'; run on hashtext(username); $$ language plproxy;
+\c test_part
+create function testfunc(username text, id integer, data text)
+returns text as $$ begin return 'username=' || username; end; $$ language plpgsql;
+\c regression
+select * from testfunc('user', 1, 'foo');
+   testfunc    
+---------------
+ username=user
+(1 row)
+
+select * from testfunc('user', 1, 'foo');
+   testfunc    
+---------------
+ username=user
+(1 row)
+
+select * from testfunc('user', 1, 'foo');
+   testfunc    
+---------------
+ username=user
+(1 row)
+
+-- test setof text
+create function test_set(username text, num integer)
+returns setof text as $$ cluster 'testcluster'; run on hashtext(username); $$ language plproxy;
+\c test_part
+create function test_set(username text, num integer)
+returns setof text as $$
+declare i integer;
+begin
+    i := 0;
+    while i < num loop
+        return next 'username=' || username || ' row=' || i;
+        i := i + 1;
+    end loop;
+    return;
+end; $$ language plpgsql;
+\c regression
+select * from test_set('user', 1);
+      test_set       
+---------------------
+ username=user row=0
+(1 row)
+
+select * from test_set('user', 0);
+ test_set 
+----------
+(0 rows)
+
+select * from test_set('user', 3);
+      test_set       
+---------------------
+ username=user row=0
+ username=user row=1
+ username=user row=2
+(3 rows)
+
+-- test record
+create type ret_test_rec as ( id integer, dat text);
+create function test_record(username text, num integer)
+returns ret_test_rec as $$ cluster 'testcluster'; run on hashtext(username); $$ language plproxy;
+\c test_part
+create type ret_test_rec as ( id integer, dat text);
+create function test_record(username text, num integer)
+returns ret_test_rec as $$
+declare ret ret_test_rec%rowtype;
+begin
+    ret := (num, username);
+    return ret;
+end; $$ language plpgsql;
+\c regression
+select * from test_record('user', 3);
+ id | dat  
+----+------
+  3 | user
+(1 row)
+
+-- test setof record
+create function test_record_set(username text, num integer)
+returns setof ret_test_rec as $$ cluster 'testcluster'; run on hashtext(username); $$ language plproxy;
+\c test_part
+create function test_record_set(username text, num integer)
+returns setof ret_test_rec as $$
+declare ret ret_test_rec%rowtype; i integer;
+begin
+    i := 0;
+    while i < num loop
+        ret := (i, username);
+        i := i + 1;
+        return next ret;
+    end loop;
+    return;
+end; $$ language plpgsql;
+\c regression
+select * from test_record_set('user', 1);
+ id | dat  
+----+------
+  0 | user
+(1 row)
+
+select * from test_record_set('user', 0);
+ id | dat 
+----+-----
+(0 rows)
+
+select * from test_record_set('user', 3);
+ id | dat  
+----+------
+  0 | user
+  1 | user
+  2 | user
+(3 rows)
+
+-- test void
+create function test_void(username text, num integer)
+returns void as $$ cluster 'testcluster'; run on hashtext(username); $$ language plproxy;
+\c test_part
+create function test_void(username text, num integer)
+returns void as $$
+begin
+    return;
+end; $$ language plpgsql;
+-- look what void actually looks
+select * from test_void('void', 2);
+ test_void 
+-----------
+ 
+(1 row)
+
+select test_void('void', 2);
+ test_void 
+-----------
+ 
+(1 row)
+
+\c regression
+select * from test_void('user', 1);
+ test_void 
+-----------
+ 
+(1 row)
+
+select * from test_void('user', 3);
+ test_void 
+-----------
+ 
+(1 row)
+
+select test_void('user', 3);
+ test_void 
+-----------
+ 
+(1 row)
+
+select test_void('user', 3);
+ test_void 
+-----------
+ 
+(1 row)
+
+-- test normal outargs
+create function test_out1(username text, id integer, out data text)
+as $$ cluster 'testcluster'; run on hashtext(username); $$ language plproxy;
+\c test_part
+create function test_out1(username text, id integer, out data text)
+returns text as $$ begin data := 'username=' || username; return; end; $$ language plpgsql;
+\c regression
+select * from test_out1('user', 1);
+     data      
+---------------
+ username=user
+(1 row)
+
+-- test complicated outargs
+create function test_out2(username text, id integer, out out_id integer, xdata text, inout xdata2 text, out odata text)
+as $$ cluster 'testcluster'; run on hashtext(username); $$ language plproxy;
+\c test_part
+create function test_out2(username text, id integer, out out_id integer, xdata text, inout xdata2 text, out odata text)
+as $$ begin
+    out_id = id;
+    xdata2 := xdata2 || xdata;
+    odata := 'username=' || username;
+    return;
+end; $$ language plpgsql;
+\c regression
+select * from test_out2('user', 1, 'xdata', 'xdata2');
+ out_id |   xdata2    |     odata     
+--------+-------------+---------------
+      1 | xdata2xdata | username=user
+(1 row)
+
+-- test various types
+create function test_types(username text, inout vbool boolean, inout xdate timestamp, inout bin bytea)
+as $$ cluster 'testcluster'; run on hashtext(username); $$ language plproxy;
+\c test_part
+create function test_types(username text, inout vbool boolean, inout xdate timestamp, inout bin bytea)
+as $$ begin return; end; $$ language plpgsql;
+\c regression
+select 1 from (select set_config(name, 'escape', false) as ignore
+          from pg_settings where name = 'bytea_output') x
+where x.ignore = 'foo';
+ ?column? 
+----------
+(0 rows)
+
+select * from test_types('types', true, '2009-11-04 12:12:02', E'a\\000\\001\\002b');
+ vbool |          xdate           |      bin       
+-------+--------------------------+----------------
+ t     | Wed Nov 04 12:12:02 2009 | a\000\001\002b
+(1 row)
+
+select * from test_types('types', NULL, NULL, NULL);
+ vbool | xdate | bin 
+-------+-------+-----
+       |       | 
+(1 row)
+
+-- test user defined types
+create domain posint as int4 check (value > 0);
+create type struct as (id int4, data text);
+create function test_types2(username text, inout v_posint posint, inout v_struct struct, inout arr int8[])
+as $$ cluster 'testcluster'; $$ language plproxy;
+\c test_part
+create domain posint as int4 check (value > 0);
+create type struct as (id int4, data text);
+create function test_types2(username text, inout v_posint posint, inout v_struct struct, inout arr int8[])
+as $$ begin return; end; $$ language plpgsql;
+\c regression
+select * from test_types2('types', 4, (2, 'asd'), array[1,2,3]);
+ v_posint | v_struct |   arr   
+----------+----------+---------
+        4 | (2,asd)  | {1,2,3}
+(1 row)
+
+select * from test_types2('types', NULL, NULL, NULL);
+ v_posint | v_struct | arr 
+----------+----------+-----
+          |          | 
+(1 row)
+
+-- test CONNECT
+create function test_connect1() returns text
+as $$ connect 'dbname=test_part host=localhost'; select current_database(); $$ language plproxy;
+select * from test_connect1();
+ test_connect1 
+---------------
+ test_part
+(1 row)
+
+-- test CONNECT $argument
+create function test_connect2(connstr text) returns text
+as $$ connect connstr; select current_database(); $$ language plproxy;
+select * from test_connect2('dbname=test_part host=localhost');
+ test_connect2 
+---------------
+ test_part
+(1 row)
+
+-- test CONNECT function($argument)
+create function test_connect3(connstr text) returns text
+as $$ connect text(connstr); select current_database(); $$ language plproxy;
+select * from test_connect3('dbname=test_part host=localhost');
+ test_connect3 
+---------------
+ test_part
+(1 row)
+
+-- test quoting function
+create type "RetWeird" as (
+    "ColId" int4,
+    "ColData" text
+);
+create function "testQuoting"(username text, id integer, data text)
+returns "RetWeird" as $$ cluster 'testcluster'; run on hashtext(username); $$ language plproxy;
+\c test_part
+create type "RetWeird" as (
+    "ColId" int4,
+    "ColData" text
+);
+create function "testQuoting"(username text, id integer, data text)
+returns "RetWeird" as $$ select 1::int4, 'BazOoka'::text $$ language sql;
+\c regression
+select * from "testQuoting"('user', '1', 'dat');
+ ColId | ColData 
+-------+---------
+     1 | BazOoka
+(1 row)
+
+-- test arg type quoting
+create domain "bad type" as text;
+create function test_argq(username text, "some arg" integer, "other arg" "bad type",
+                          out "bad out" text, out "bad out2" "bad type")
+as $$ cluster 'testcluster'; run on hashtext(username); $$ language plproxy;
+\c test_part
+create domain "bad type" as text;
+create function test_argq(username text, "some arg" integer, "other arg" "bad type",
+                          out "bad out" text, out "bad out2" "bad type")
+                    as $$ begin return; end; $$ language plpgsql;
+\c regression
+select * from test_argq('user', 1, 'q');
+ bad out | bad out2 
+---------+----------
+         | 
+(1 row)
+
+-- test hash types function
+create or replace function t_hash16(int4) returns int2 as $$
+declare
+    res int2;
+begin
+    res = $1::int2;
+    return res;
+end;
+$$ language plpgsql;
+create or replace function t_hash64(int4) returns int8 as $$
+declare
+    res int8;
+begin
+    res = $1;
+    return res;
+end;
+$$ language plpgsql;
+create function test_hash16(id integer, data text)
+returns text as $$ cluster 'testcluster'; run on t_hash16(id); select data; $$ language plproxy;
+select * from test_hash16('0', 'hash16');
+ test_hash16 
+-------------
+ hash16
+(1 row)
+
+create function test_hash64(id integer, data text)
+returns text as $$ cluster 'testcluster'; run on t_hash64(id); select data; $$ language plproxy;
+select * from test_hash64('0', 'hash64');
+ test_hash64 
+-------------
+ hash64
+(1 row)
+
+-- test argument difference
+\c test_part
+create function test_difftypes(username text, out val1 int2, out val2 float8)
+as $$ begin val1 = 1; val2 = 3;return; end; $$ language plpgsql;
+\c regression
+create function test_difftypes(username text, out val1 int4, out val2 float4)
+as $$ cluster 'testcluster'; run on 0; $$ language plproxy;
+select * from test_difftypes('types');
+ val1 | val2 
+------+------
+    1 |    3
+(1 row)
+
+-- test simple hash
+\c test_part
+create function test_simple(partno int4) returns int4
+as $$ begin return $1; end; $$ language plpgsql;
+\c regression
+create function test_simple(partno int4) returns int4
+as $$
+    cluster 'testcluster';
+    run on $1;
+$$ language plproxy;
+select * from test_simple(0);
+ test_simple 
+-------------
+           0
+(1 row)
+
+drop function test_simple(int4);
+create function test_simple(partno int4) returns int4
+as $$
+    cluster 'testcluster';
+    run on partno;
+$$ language plproxy;
+select * from test_simple(0);
+ test_simple 
+-------------
+           0
+(1 row)
+
+-- test error passing
+\c test_part
+create function test_error1() returns int4
+as $$
+begin
+    select line2err;
+    return 0;
+end;
+$$ language plpgsql;
+\c regression
+create function test_error1() returns int4
+as $$
+    cluster 'testcluster';
+    run on 0;
+$$ language plproxy;
+select * from test_error1();
+ERROR:  public.test_error1(0): [test_part] REMOTE ERROR: column "line2err" does not exist at character 8
+create function test_error2() returns int4
+as $$
+    cluster 'testcluster';
+    run on 0;
+    select err;
+$$ language plproxy;
+select * from test_error2();
+NOTICE:  PL/Proxy: dropping stale conn
+ERROR:  public.test_error2(0): [test_part] REMOTE ERROR: column "err" does not exist at character 8
+create function test_error3() returns int4
+as $$
+    connect 'dbname=test_part host=localhost';
+$$ language plproxy;
+select * from test_error3();
+ERROR:  public.test_error3(0): [test_part] REMOTE ERROR: function public.test_error3() does not exist at character 21
+-- test invalid db
+create function test_bad_db() returns int4
+as $$
+    cluster 'badcluster';
+$$ language plproxy;
+select * from test_bad_db();
+ERROR:  PL/Proxy function public.test_bad_db(0): [nonex_db] PQconnectPoll: FATAL:  database "nonex_db" does not exist
+
+create function test_bad_db2() returns int4
+as $$
+    connect 'dbname=wrong_name_db host=localhost';
+$$ language plproxy;
+select * from test_bad_db2();
+ERROR:  PL/Proxy function public.test_bad_db2(0): [wrong_name_db] PQconnectPoll: FATAL:  database "wrong_name_db" does not exist
+

--- a/test/sql/plproxy_encoding.sql
+++ b/test/sql/plproxy_encoding.sql
@@ -24,7 +24,7 @@ create database test_enc_part with encoding 'utf-8' template template0;
 \c test_enc_proxy
 set client_encoding = 'utf-8';
 set client_min_messages = 'fatal';
-create language plpgsql;
+create or replace language plpgsql;
 set client_min_messages = 'warning';
 \set ECHO none
 \i sql/plproxy.sql
@@ -53,7 +53,7 @@ $$ language plproxy;
 -- initialize part db
 \c test_enc_part
 set client_min_messages = 'fatal';
-create language plpgsql;
+create or replace language plpgsql;
 set client_min_messages = 'warning';
 set client_encoding = 'utf8';
 create table intl_data (id int4, "コラム" text);
@@ -95,7 +95,7 @@ create database test_enc_part with encoding 'euc_jp' template template0;
 -- initialize proxy db
 \c test_enc_proxy
 set client_min_messages = 'fatal';
-create language plpgsql;
+create or replace language plpgsql;
 set client_min_messages = 'warning';
 \set ECHO none
 \i sql/plproxy.sql
@@ -126,7 +126,7 @@ $$ language plproxy;
 -- initialize part db
 \c test_enc_part
 set client_min_messages = 'fatal';
-create language plpgsql;
+create or replace language plpgsql;
 set client_min_messages = 'warning';
 set client_encoding = 'utf8';
 create table intl_data (id int4, "コラム" text);

--- a/test/sql/plproxy_init.sql
+++ b/test/sql/plproxy_init.sql
@@ -6,7 +6,7 @@ set client_min_messages = 'warning';
 \i sql/plproxy.sql
 
 set client_min_messages = 'fatal';
-create language plpgsql;
+create or replace language plpgsql;
 set client_min_messages = 'warning';
 
 -- create cluster info functions
@@ -67,16 +67,16 @@ drop database if exists test_enc_part;
 
 \c test_part
 set client_min_messages = 'fatal';
-create language plpgsql;
+create or replace language plpgsql;
 \c test_part0
 set client_min_messages = 'fatal';
-create language plpgsql;
+create or replace language plpgsql;
 \c test_part1
 set client_min_messages = 'fatal';
-create language plpgsql;
+create or replace language plpgsql;
 \c test_part2
 set client_min_messages = 'fatal';
-create language plpgsql;
+create or replace language plpgsql;
 \c test_part3
 set client_min_messages = 'fatal';
-create language plpgsql;
+create or replace language plpgsql;

--- a/test/sql/plproxy_init.sql
+++ b/test/sql/plproxy_init.sql
@@ -5,7 +5,7 @@ set client_min_messages = 'warning';
 
 \i sql/plproxy.sql
 
-set client_min_messages = 'fatal';
+set client_min_messages = 'error';
 create or replace language plpgsql;
 set client_min_messages = 'warning';
 
@@ -66,17 +66,17 @@ drop database if exists test_enc_proxy;
 drop database if exists test_enc_part;
 
 \c test_part
-set client_min_messages = 'fatal';
+set client_min_messages = 'error';
 create or replace language plpgsql;
 \c test_part0
-set client_min_messages = 'fatal';
+set client_min_messages = 'error';
 create or replace language plpgsql;
 \c test_part1
-set client_min_messages = 'fatal';
+set client_min_messages = 'error';
 create or replace language plpgsql;
 \c test_part2
-set client_min_messages = 'fatal';
+set client_min_messages = 'error';
 create or replace language plpgsql;
 \c test_part3
-set client_min_messages = 'fatal';
+set client_min_messages = 'error';
 create or replace language plpgsql;


### PR DESCRIPTION
I've adjusted the source code in order to compile against PostgreSQL 12 (beta2) on Linux.
The main difference is that OID column is now an ordinary column and not an hidden one, so `HeapTupleGetOid` is no longer availabled.

This is also based on #37 , so it gets "for free" also PostgreSQL 11 and FreeBSD as target systems.