### PR TITLE
Request to merge Cybertec patches

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ REGRESS = plproxy_init plproxy_test plproxy_select plproxy_many \
      plproxy_errors plproxy_clustermap plproxy_dynamic_record \
      plproxy_encoding plproxy_split plproxy_target plproxy_alter \
      plproxy_cancel plproxy_range plproxy_sqlmed plproxy_table \
-     plproxy_modular
+     plproxy_modular plproxy_execute
 REGRESS_OPTS = --inputdir=test
 
 # use known db name

--- a/doc/syntax.md
+++ b/doc/syntax.md
@@ -149,6 +149,44 @@ will run following query on remote side:
 
     SELECT * FROM other_function(username, num);
 
+## EXECUTE
+
+    EXECUTE argname ;
+
+Executes the specified argument as a query on remote side. The argument
+datatype must be text. Cannot be combined with `TARGET` or `SELECT`. 
+
+For more flexibility, this can be combined with `SPLIT` and `RUN ON`. For example
+with the following function, each node can run different queries:
+
+    CREATE FUNCTION run_query(partitions int[], queries text[])
+    RETURNS SETOF my_record_type AS $$
+        CLUSTER 'userdb';
+        SPLIT partitions, queries;
+        RUN ON partitions;
+        EXECUTE queries;
+    $$ LANGUAGE plproxy;
+
+The partition and queries can then be passed in as two arrays:
+
+    SELECT * FROM run_query(array[0, 2], array[
+        'SELECT * FROM table_in_partition0',
+        'SELECT * FROM table_in_partition2'
+    ]);
+
+To execute the same query on all nodes:
+
+    CREATE FUNCTION run_query(query text)
+    RETURNS SETOF my_record_type AS $$
+        CLUSTER 'userdb';
+        RUN ON ALL;
+        EXECUTE query;
+    $$ LANGUAGE plproxy;
+
+The main benefit of this approach is that it avoid a function call on the
+remote side, which would disable parallel execution.
+
+
 ## SELECT
 
     SELECT .... ;

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -110,6 +110,8 @@ static void conn_free(struct AANode *node, void *arg)
 	aatree_destroy(&conn->userstate_tree);
 	if (conn->res)
 		PQclear(conn->res);
+	if (conn->result_map)
+		pfree(conn->result_map);
 	pfree(conn);
 }
 
@@ -1314,6 +1316,12 @@ static void clean_conn(struct AANode *node, void *arg)
 		conn->res = NULL;
 	}
 
+	if (conn->result_map)
+	{
+		pfree(conn->result_map);
+		conn->result_map = NULL;
+	}
+
 	aatree_walk(&conn->userstate_tree, AA_WALK_IN_ORDER, clean_state, maint);
 }
 
@@ -1335,3 +1343,8 @@ plproxy_cluster_maint(struct timeval * now)
 	aatree_walk(&fake_cluster_tree, AA_WALK_IN_ORDER, clean_cluster, now);
 }
 
+void *
+plproxy_allocate_memory(size_t size)
+{
+	return MemoryContextAllocZero(cluster_mem, size);
+}

--- a/src/execute.c
+++ b/src/execute.c
@@ -198,6 +198,14 @@ send_query(ProxyFunction *func, ProxyConnection *conn,
 	if (!res)
 		conn_error(func, conn, "PQsendQueryParams");
 
+	if (func->retset)
+	{
+		res = PQsetSingleRowMode(conn->cur->db);
+
+		if (!res)
+			conn_error(func, conn, "PQsetSingleRowMode");
+	}
+
 	/* flush it down */
 	flush_connection(func, conn);
 }
@@ -331,15 +339,17 @@ prepare_conn(ProxyFunction *func, ProxyConnection *conn)
 }
 
 /*
- * Connection has a resultset avalable, fetch it.
+ * Connection has a result avalable, store it in the result tuplestore.
  *
  * Returns true if there may be more results coming,
  * false if all done.
  */
 static bool
-another_result(ProxyFunction *func, ProxyConnection *conn)
+another_result(ProxyFunction *func, ProxyConnection *conn, FunctionCallInfo fcinfo)
 {
-	PGresult   *res;
+	PGresult	  *res;
+	ReturnSetInfo *rsinfo;
+	HeapTuple	   tuple;
 
 	/* got one */
 	res = PQgetResult(conn->cur->db);
@@ -360,9 +370,27 @@ another_result(ProxyFunction *func, ProxyConnection *conn)
 		return true;
 	}
 
+	rsinfo = (ReturnSetInfo *) fcinfo->resultinfo;
+
 	switch (PQresultStatus(res))
 	{
+		case PGRES_SINGLE_TUPLE:
+			Assert(rsinfo->setDesc);
+
+			tuple = plproxy_tuple_from_result(res, rsinfo->setDesc, func);
+
+			tuplestore_puttuple(rsinfo->setResult, tuple);
+
+			PQclear(res);
+			break;
 		case PGRES_TUPLES_OK:
+			/* in single row mode, this is empty */
+			if (func->retset)
+			{
+				PQclear(res);
+				break;
+			}
+
 			if (conn->res)
 			{
 				PQclear(res);
@@ -370,21 +398,13 @@ another_result(ProxyFunction *func, ProxyConnection *conn)
 			}
 			conn->res = res;
 			break;
-		case PGRES_COMMAND_OK:
+		case PGRES_COMMAND_OK:		/* no result */
 			PQclear(res);
 			break;
 		case PGRES_FATAL_ERROR:
-			if (conn->res)
-				PQclear(conn->res);
-			conn->res = res;
-
 			plproxy_remote_error(func, conn, res, true);
 			break;
 		default:
-			if (conn->res)
-				PQclear(conn->res);
-			conn->res = res;
-
 			plproxy_error(func, "Unexpected result type: %s", PQresStatus(PQresultStatus(res)));
 			break;
 	}
@@ -397,7 +417,7 @@ another_result(ProxyFunction *func, ProxyConnection *conn)
  * It should call postgres handlers and then change state if needed.
  */
 static void
-handle_conn(ProxyFunction *func, ProxyConnection *conn)
+handle_conn(ProxyFunction *func, ProxyConnection *conn, FunctionCallInfo fcinfo)
 {
 	int			res;
 	PostgresPollingStatusType poll_res;
@@ -439,7 +459,7 @@ handle_conn(ProxyFunction *func, ProxyConnection *conn)
 					break;
 
 				/* got one */
-				if (!another_result(func, conn))
+				if (!another_result(func, conn, fcinfo))
 					break;
 			}
 		case C_NONE:
@@ -456,7 +476,7 @@ handle_conn(ProxyFunction *func, ProxyConnection *conn)
  * on small number of sockets.
  */
 static int
-poll_conns(ProxyFunction *func, ProxyCluster *cluster)
+poll_conns(ProxyFunction *func, ProxyCluster *cluster, FunctionCallInfo fcinfo)
 {
 	static struct pollfd *pfd_cache = NULL;
 	static int pfd_allocated = 0;
@@ -555,7 +575,7 @@ poll_conns(ProxyFunction *func, ProxyCluster *cluster)
 			elog(WARNING, "fd order from poll() is messed up?");
 
 		if (pf->revents)
-			handle_conn(func, conn);
+			handle_conn(func, conn, fcinfo);
 
 		pf++;
 	}
@@ -594,14 +614,14 @@ check_timeouts(ProxyFunction *func, ProxyCluster *cluster, ProxyConnection *conn
 
 /* Run the query on all tagged connections in parallel */
 static void
-remote_execute(ProxyFunction *func)
+remote_execute(ProxyFunction *func, FunctionCallInfo fcinfo)
 {
-	ExecStatusType err;
 	ProxyConnection *conn;
 	ProxyCluster *cluster = func->cur_cluster;
 	int			i,
 				pending = 0;
 	struct timeval now;
+	ReturnSetInfo *rsinfo = (ReturnSetInfo *) fcinfo->resultinfo;
 
 	/* either launch connection or send query */
 	for (i = 0; i < cluster->active_count; i++)
@@ -626,7 +646,7 @@ remote_execute(ProxyFunction *func)
 		CHECK_FOR_INTERRUPTS();
 
 		/* wait for events */
-		if (poll_conns(func, cluster) == 0)
+		if (poll_conns(func, cluster, fcinfo) == 0)
 			continue;
 
 		/* recheck */
@@ -654,7 +674,7 @@ remote_execute(ProxyFunction *func)
 	{
 		conn = cluster->active_list[i];
 
-		if ((conn->run_tag || conn->res)
+		if (!func->retset && (conn->run_tag || conn->res)
 			&& !(conn->run_tag && conn->res))
 			plproxy_error(func, "run_tag does not match res");
 
@@ -663,15 +683,28 @@ remote_execute(ProxyFunction *func)
 
 		if (conn->cur->state != C_DONE)
 			plproxy_error(func, "Unfinished connection");
-		if (conn->res == NULL)
-			plproxy_error(func, "Lost result");
 
-		err = PQresultStatus(conn->res);
-		if (err != PGRES_TUPLES_OK)
-			plproxy_error(func, "Remote error: %s",
-						  PQresultErrorMessage(conn->res));
+		if (!func->retset)
+		{
+			ExecStatusType err;
 
-		cluster->ret_total += PQntuples(conn->res);
+			if (conn->res == NULL)
+				plproxy_error(func, "Lost result");
+
+			err = PQresultStatus(conn->res);
+			if (err != PGRES_TUPLES_OK)
+				plproxy_error(func, "Remote error: %s",
+							  PQresultErrorMessage(conn->res));
+
+			cluster->ret_total += PQntuples(conn->res);
+		}
+	}
+
+	if (func->retset)
+	{
+		tuplestore_donestoring(rsinfo->setResult);
+
+		cluster->ret_total = tuplestore_tuple_count(rsinfo->setResult);
 	}
 }
 
@@ -707,7 +740,7 @@ remote_wait_for_cancel(ProxyFunction *func)
 			break;
 
 		/* wait for events */
-		poll_conns(func, cluster);
+		poll_conns(func, cluster, NULL);
 	}
 
 	/* review results, calculate total */
@@ -1242,7 +1275,7 @@ plproxy_exec(ProxyFunction *func, FunctionCallInfo fcinfo)
 		/* prepare target queries */
 		prepare_queries(func, fcinfo);
 
-		remote_execute(func);
+		remote_execute(func, fcinfo);
 
 		func->cur_cluster->busy = false;
 	}

--- a/src/execute.c
+++ b/src/execute.c
@@ -377,7 +377,7 @@ another_result(ProxyFunction *func, ProxyConnection *conn, FunctionCallInfo fcin
 		case PGRES_SINGLE_TUPLE:
 			Assert(rsinfo->setDesc);
 
-			tuple = plproxy_tuple_from_result(res, rsinfo->setDesc, func);
+			tuple = plproxy_tuple_from_result(res, rsinfo->setDesc, func, conn);
 
 			tuplestore_puttuple(rsinfo->setResult, tuple);
 

--- a/src/function.c
+++ b/src/function.c
@@ -431,7 +431,6 @@ fn_get_return_type(ProxyFunction *func,
 	TupleDesc	ret_tup;
 	TypeFuncClass rtc;
 	MemoryContext old_ctx;
-	int			natts;
 	Form_pg_proc proc_struct;
 
 	/* is it a set returning function? */
@@ -452,12 +451,9 @@ fn_get_return_type(ProxyFunction *func,
 	{
 		case TYPEFUNC_COMPOSITE:
 			func->ret_composite = plproxy_composite_info(func, ret_tup);
-			natts = func->ret_composite->tupdesc->natts;
-			func->result_map = plproxy_func_alloc(func, natts * sizeof(int));
 			break;
 		case TYPEFUNC_SCALAR:
 			func->ret_scalar = plproxy_find_type_info(func, ret_oid, 0);
-			func->result_map = NULL;
 			break;
 		case TYPEFUNC_RECORD:
 		case TYPEFUNC_OTHER:
@@ -482,7 +478,6 @@ fn_refresh_record(FunctionCallInfo fcinfo,
 	TupleDesc tuple_current, tuple_cached;
 	MemoryContext old_ctx;
 	Oid tuple_oid;
-	int natts;
 	TypeFuncClass rtc;
 
 	/*
@@ -503,13 +498,10 @@ fn_refresh_record(FunctionCallInfo fcinfo,
 
 	/* release old data */
 	plproxy_free_composite(func->ret_composite);
-	pfree(func->result_map);
 	pfree(func->remote_sql);
 
 	/* construct new data */
 	func->ret_composite = plproxy_composite_info(func, tuple_current);
-	natts = func->ret_composite->tupdesc->natts;
-	func->result_map = plproxy_func_alloc(func, natts * sizeof(int));
 	func->remote_sql = plproxy_standard_query(func, true);
 }
 

--- a/src/function.c
+++ b/src/function.c
@@ -149,6 +149,27 @@ plproxy_split_all_arrays(ProxyFunction *func)
 	}
 }
 
+/* Add execute by identifier */
+bool
+plproxy_execute_ident(ProxyFunction *func, const char *ident)
+{
+	int		argindex;
+	ProxyType* type;
+
+	if ((argindex = plproxy_get_parameter_index(func, ident)) < 0)
+		return false;
+
+	type = func->arg_types[argindex];
+	if ((type->is_array ? type->elem_type_oid : type->type_oid) != TEXTOID)
+		plproxy_error(func, "EXECUTE parameter is not text: %s", ident);
+
+	func->is_execute = true;
+	func->execute_arg = argindex;
+	func->execute_is_array = type->is_array;
+
+	return true;
+}
+
 /* Initialize PL/Proxy function cache */
 void
 plproxy_function_cache_init(void)

--- a/src/function.c
+++ b/src/function.c
@@ -262,16 +262,23 @@ fn_new(HeapTuple proc_tuple)
 {
 	ProxyFunction *f;
 	MemoryContext f_ctx,
+				tup_ctx,
 				old_ctx;
 
 	f_ctx = AllocSetContextCreate(TopMemoryContext,
 								  "PL/Proxy function context",
 								  ALLOCSET_SMALL_SIZES);
 
+	/* memory context for short-lived memory during tuple creation */
+	tup_ctx = AllocSetContextCreate(f_ctx,
+									"PL/Proxy tuple creation context",
+									ALLOCSET_SMALL_SIZES);
+
 	old_ctx = MemoryContextSwitchTo(f_ctx);
 
 	f = palloc0(sizeof(*f));
 	f->ctx = f_ctx;
+	f->tuplectx = tup_ctx;
 	f->oid = XProcTupleGetOid(proc_tuple);
 	plproxy_set_stamp(&f->stamp, proc_tuple);
 
@@ -425,7 +432,11 @@ fn_get_return_type(ProxyFunction *func,
 	TypeFuncClass rtc;
 	MemoryContext old_ctx;
 	int			natts;
+	Form_pg_proc proc_struct;
 
+	/* is it a set returning function? */
+	proc_struct = (Form_pg_proc) GETSTRUCT(proc_tuple);
+	func->retset = proc_struct->proretset;
 
 	/*
 	 * get_call_result_type() will return newly allocated tuple,

--- a/src/main.c
+++ b/src/main.c
@@ -155,6 +155,60 @@ run_maint(void)
 	plproxy_cluster_maint(&now);
 }
 
+/* Set up tuple descriptor and tuple store */
+static void
+plproxy_setup_tuplestore(ProxyFunction *func, FunctionCallInfo fcinfo)
+{
+	TupleDesc tupdesc;
+	ReturnSetInfo *rsinfo = (ReturnSetInfo *) fcinfo->resultinfo;
+	Oid result_type;
+	MemoryContext old_ctx;
+
+	/* check to see if query supports us returning a tuplestore */
+	if (rsinfo == NULL || !IsA(rsinfo, ReturnSetInfo))
+		ereport(ERROR,
+				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+				 errmsg("set-valued function called in context that cannot accept a set")));
+	if (!(rsinfo->allowedModes & SFRM_Materialize))
+		ereport(ERROR,
+				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+				 errmsg("materialize mode required, but it is not allowed in this context")));
+
+	/* let the executor know we're sending back a tuplestore */
+	rsinfo->returnMode = SFRM_Materialize;
+
+	switch (get_call_result_type(fcinfo, &result_type, &tupdesc))
+	{
+		case TYPEFUNC_COMPOSITE:
+		case TYPEFUNC_COMPOSITE_DOMAIN:
+			Assert(tupdesc);
+			break;
+		case TYPEFUNC_RECORD:
+			/* don't support generic "record" type */
+			ereport(ERROR,
+					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+					 errmsg("function returning record called in context "
+							"that cannot accept type record")));
+			break;
+		default:
+			Assert(!tupdesc);
+			tupdesc = CreateTemplateTupleDesc(1, false);
+			TupleDescInitEntry(tupdesc, (AttrNumber) 1, "result",
+							   result_type, -1, 0);
+	}
+
+	/* create tuplestore and tuple descriptor in a persisient memory context */
+	old_ctx = MemoryContextSwitchTo(rsinfo->econtext->ecxt_per_query_memory);
+
+	/* create a transaction-only random access tuplestore */
+	rsinfo->setResult = tuplestore_begin_heap(true, false, work_mem);
+
+	/* make sure we have a persistent copy of the tuple descriptor */
+	rsinfo->setDesc = CreateTupleDescCopy(tupdesc);
+
+	MemoryContextSwitchTo(old_ctx);
+}
+
 /*
  * Do compilation and execution under SPI.
  *
@@ -185,6 +239,10 @@ compile_and_execute(FunctionCallInfo fcinfo)
 	if (cluster->busy)
 		plproxy_error(func, "Nested PL/Proxy calls to the same cluster are not supported.");
 
+	/* set up result tuplestore for table functions if requested */
+	if (fcinfo->flinfo->fn_retset)
+		plproxy_setup_tuplestore(func, fcinfo);
+
 	/* fetch PGresults */
 	func->cur_cluster = cluster;
 	plproxy_exec(func, fcinfo);
@@ -207,27 +265,11 @@ static Datum
 handle_ret_set(FunctionCallInfo fcinfo)
 {
 	ProxyFunction *func;
-	FuncCallContext *ret_ctx;
 
-	if (SRF_IS_FIRSTCALL())
-	{
-		func = compile_and_execute(fcinfo);
-		ret_ctx = SRF_FIRSTCALL_INIT();
-		ret_ctx->user_fctx = func;
-	}
+	func = compile_and_execute(fcinfo);
 
-	ret_ctx = SRF_PERCALL_SETUP();
-	func = ret_ctx->user_fctx;
-
-	if (func->cur_cluster->ret_total > 0)
-	{
-		SRF_RETURN_NEXT(ret_ctx, plproxy_result(func, fcinfo));
-	}
-	else
-	{
-		plproxy_clean_results(func->cur_cluster);
-		SRF_RETURN_DONE(ret_ctx);
-	}
+	plproxy_clean_results(func->cur_cluster);
+	PG_RETURN_NULL();
 }
 
 /*

--- a/src/plproxy.h
+++ b/src/plproxy.h
@@ -98,6 +98,21 @@
  */
 #define PLPROXY_IDLE_CONN_CHECK		2
 
+/* Temp structure for query parsing */
+typedef struct QueryBuffer QueryBuffer;
+
+/*
+ * Parsed query where references to function arguments
+ * are replaced with local args numbered sequentially: $1..$n.
+ */
+typedef struct ProxyQuery
+{
+	char	   *sql;			/* Prepared SQL string */
+	int			arg_count;		/* Argument count for ->sql */
+	int		   *arg_lookup;		/* Maps local references to function args */
+	void	   *plan;			/* Optional prepared plan for local queries */
+} ProxyQuery;
+
 /* Flag indicating where function should be executed */
 typedef enum RunOnType
 {
@@ -183,6 +198,7 @@ typedef struct ProxyConnection
 
 	Datum			   *split_params;					/* Split array parameters */
 	ArrayBuildState	  **bstate;							/* Temporary build state */
+	ProxyQuery  	   *remote_sql;							/* Query to execute */
 	const char		   *param_values[FUNC_MAX_ARGS];	/* Parameter values */
 	int					param_lengths[FUNC_MAX_ARGS];	/* Parameter lengths (binary io) */
 	int					param_formats[FUNC_MAX_ARGS];	/* Parameter formats (binary io) */
@@ -286,21 +302,6 @@ typedef struct ProxyComposite
 	RowStamp	stamp;
 } ProxyComposite;
 
-/* Temp structure for query parsing */
-typedef struct QueryBuffer QueryBuffer;
-
-/*
- * Parsed query where references to function arguments
- * are replaced with local args numbered sequentially: $1..$n.
- */
-typedef struct ProxyQuery
-{
-	char	   *sql;			/* Prepared SQL string */
-	int			arg_count;		/* Argument count for ->sql */
-	int		   *arg_lookup;		/* Maps local references to function args */
-	void	   *plan;			/* Optional prepared plan for local queries */
-} ProxyQuery;
-
 /*
  * Deconstructed array parameters
  */
@@ -349,6 +350,10 @@ typedef struct ProxyFunction
 	ProxyQuery *connect_sql;	/* Optional query for CONNECT function */
 	const char *target_name;	/* Optional target function name */
 
+	bool	is_execute;
+	int		execute_arg;
+	bool	execute_is_array;
+
 	/*
 	 * calculated data
 	 */
@@ -387,6 +392,7 @@ char	   *plproxy_func_strdup(ProxyFunction *func, const char *s);
 int			plproxy_get_parameter_index(ProxyFunction *func, const char *ident);
 bool		plproxy_split_add_ident(ProxyFunction *func, const char *ident);
 void		plproxy_split_all_arrays(ProxyFunction *func);
+bool		plproxy_execute_ident(ProxyFunction *func, const char *ident);
 ProxyFunction *plproxy_compile_and_cache(FunctionCallInfo fcinfo);
 ProxyFunction *plproxy_compile(FunctionCallInfo fcinfo, HeapTuple proc_tuple, bool validate_only);
 

--- a/src/plproxy.h
+++ b/src/plproxy.h
@@ -182,6 +182,11 @@ typedef struct ProxyConnection
 
 	/* state */
 	PGresult   *res;			/* last resultset */
+	/*
+	 * Maps result field num to libpq column num.
+	 * NULL when scalar result.
+	 */
+	int		   *result_map;
 	int			pos;			/* Current position inside res */
 	ProxyConnectionState *cur;
 
@@ -372,12 +377,6 @@ typedef struct ProxyFunction
 	 * function's private fake cluster object.
 	 */
 	ProxyCluster *cur_cluster;
-
-	/*
-	 * Maps result field num to libpq column num.
-	 * It is filled for each result.  NULL when scalar result.
-	 */
-	int		   *result_map;
 } ProxyFunction;
 
 /* main.c */
@@ -434,10 +433,11 @@ ProxyCluster *plproxy_find_cluster(ProxyFunction *func, FunctionCallInfo fcinfo)
 void		plproxy_cluster_maint(struct timeval * now);
 void		plproxy_activate_connection(struct ProxyConnection *conn);
 void		plproxy_append_cstr_option(StringInfo cstr, const char *name, const char *val);
+void	   *plproxy_allocate_memory(size_t size);
 
 /* result.c */
 Datum		plproxy_result(ProxyFunction *func, FunctionCallInfo fcinfo);
-HeapTuple	plproxy_tuple_from_result(PGresult *res, TupleDesc tupdesc, ProxyFunction *func);
+HeapTuple	plproxy_tuple_from_result(PGresult *res, TupleDesc tupdesc, ProxyFunction *func, ProxyConnection *conn);
 
 /* query.c */
 QueryBuffer *plproxy_query_start(ProxyFunction *func, bool add_types);

--- a/src/plproxy.h
+++ b/src/plproxy.h
@@ -323,6 +323,7 @@ typedef struct ProxyFunction
 	const char *name;			/* Fully-qualified and quoted function name */
 	Oid			oid;			/* Function OID */
 	MemoryContext ctx;			/* Where runtime allocations should happen */
+	MemoryContext tuplectx;		/* short-lived memory for tuple creation */
 
 	RowStamp	stamp;			/* for pg_proc cache validation */
 
@@ -331,6 +332,8 @@ typedef struct ProxyFunction
 	short		arg_count;		/* Argument count of proxy function */
 
 	bool	   *split_args;		/* Map of arguments to split */
+
+	bool		retset;			/* set returning function */
 
 	/* if the function returns untyped RECORD that needs AS clause */
 	bool		dynamic_record;
@@ -434,6 +437,7 @@ void		plproxy_append_cstr_option(StringInfo cstr, const char *name, const char *
 
 /* result.c */
 Datum		plproxy_result(ProxyFunction *func, FunctionCallInfo fcinfo);
+HeapTuple	plproxy_tuple_from_result(PGresult *res, TupleDesc tupdesc, ProxyFunction *func);
 
 /* query.c */
 QueryBuffer *plproxy_query_start(ProxyFunction *func, bool add_types);

--- a/src/result.c
+++ b/src/result.c
@@ -37,9 +37,9 @@ name_matches(ProxyFunction *func, const char *aname, PGresult *res, int col)
 	return false;
 }
 
-/* fill func->result_map */
+/* fill conn->result_map */
 static void
-map_results(ProxyFunction *func, PGresult *res)
+map_results(ProxyFunction *func, ProxyConnection *conn, PGresult *res)
 {
 	int			i,  /* non-dropped column index */
 				xi, /* tupdesc index */
@@ -48,6 +48,10 @@ map_results(ProxyFunction *func, PGresult *res)
 				nfields = PQnfields(res);
 	Form_pg_attribute a;
 	const char *aname;
+
+	if (conn->result_map)
+		pfree(conn->result_map);
+	conn->result_map = NULL;
 
 	if (func->ret_scalar)
 	{
@@ -63,12 +67,14 @@ map_results(ProxyFunction *func, PGresult *res)
 	if (nfields > func->ret_composite->nfields)
 		plproxy_error(func, "Got too many fields from remote end");
 
+	conn->result_map = plproxy_allocate_memory(natts * sizeof(int));
+
 	for (i = -1, xi = 0; xi < natts; xi++)
 	{
 		/* ->name_list has quoted names, take unquoted from ->tupdesc */
 		a = TupleDescAttr(func->ret_composite->tupdesc, xi);
 
-		func->result_map[xi] = -1;
+		conn->result_map[xi] = -1;
 
 		if (a->attisdropped)
 			continue;
@@ -77,7 +83,7 @@ map_results(ProxyFunction *func, PGresult *res)
 		aname = NameStr(a->attname);
 		if (name_matches(func, aname, res, i))
 			/* fast case: 1:1 mapping */
-			func->result_map[xi] = i;
+			conn->result_map[xi] = i;
 		else
 		{
 			/* slow case: messed up ordering */
@@ -92,12 +98,12 @@ map_results(ProxyFunction *func, PGresult *res)
 				 */
 				if (name_matches(func, aname, res, j))
 				{
-					func->result_map[xi] = j;
+					conn->result_map[xi] = j;
 					break;
 				}
 			}
 		}
-		if (func->result_map[xi] < 0)
+		if (conn->result_map[xi] < 0)
 			plproxy_error(func,
 						  "Field %s does not exists in result", aname);
 	}
@@ -120,7 +126,7 @@ walk_results(ProxyFunction *func, ProxyCluster *cluster)
 
 		/* first time on this connection? */
 		if (conn->pos == 0)
-			map_results(func, conn->res);
+			map_results(func, conn, conn->res);
 
 		return conn;
 	}
@@ -147,7 +153,7 @@ return_composite(ProxyFunction *func, ProxyConnection *conn, FunctionCallInfo fc
 
 	for (i = 0; i < meta->tupdesc->natts; i++)
 	{
-		col = func->result_map[i];
+		col = conn->result_map[i];
 		if (col < 0 || PQgetisnull(conn->res, conn->pos, col))
 		{
 			values[i] = NULL;
@@ -225,7 +231,7 @@ plproxy_result(ProxyFunction *func, FunctionCallInfo fcinfo)
  * Build a HeapTuple from a single-row query result.
  */
 HeapTuple
-plproxy_tuple_from_result(PGresult *res, TupleDesc tupdesc, ProxyFunction *func)
+plproxy_tuple_from_result(PGresult *res, TupleDesc tupdesc, ProxyFunction *func, ProxyConnection *conn)
 {
 	int	nfields = PQnfields(res);
 	HeapTuple tuple;
@@ -239,6 +245,11 @@ plproxy_tuple_from_result(PGresult *res, TupleDesc tupdesc, ProxyFunction *func)
 				(errcode(ERRCODE_DATATYPE_MISMATCH),
 				 errmsg("remote query result rowtype does not match "
 						"the specified FROM clause rowtype")));
+
+	/* get the result column mapping when the first row is processed */
+	if (conn->pos == 0)
+		map_results(func, conn, res);
+	++conn->pos;
 
 	/* switch to temporary memory context */
 	old_ctx = MemoryContextSwitchTo(func->tuplectx);
@@ -262,61 +273,63 @@ plproxy_tuple_from_result(PGresult *res, TupleDesc tupdesc, ProxyFunction *func)
 		/* result contains only binary data */
 		for (i = 0; i < nfields; i++)
 		{
-			if (PQgetisnull(res, 0, i))
+			Datum d = 0;
+			int typsize;
+			int colpos = conn->result_map ? conn->result_map[i] : i;
+
+			if (PQgetisnull(res, 0, colpos))
+			{
 				nulls[i] = true;
+				continue;
+			}
+
+			nulls[i] = false;
+
+			/* convert binary representation to Datum */
+			if ((typsize = PQfsize(res, colpos)) == -1)
+			{
+				/* varlena */
+				int dlen = PQgetlength(res, 0, colpos);
+				struct varlena *v = palloc(dlen + VARHDRSZ);
+
+				SET_VARSIZE(v, dlen + VARHDRSZ);
+				memcpy(VARDATA(v), PQgetvalue(res, 0, colpos), dlen);
+
+				d = PointerGetDatum(v);
+			}
 			else
 			{
-				Datum d;
-				int typsize;
+				union {
+					int32 i4[2];
+					int64 i8;
+				} x;
+				int32 s;
 
-				nulls[i] = false;
-
-				/* convert binary representation to Datum */
-				if ((typsize = PQfsize(res, i)) == -1)
+				/* must convert from network byte order to host byte order */
+				switch(typsize)
 				{
-					/* varlena */
-					int dlen = PQgetlength(res, 0, i);
-					struct varlena *v = palloc(dlen + VARHDRSZ);
-
-					SET_VARSIZE(v, dlen + VARHDRSZ);
-					memcpy(VARDATA(v), PQgetvalue(res, 0, i), dlen);
-
-					d = PointerGetDatum(v);
-				}
-				else
-				{
-					union {
-						int32 i4[2];
-						int64 i8;
-					} x;
-					int32 s;
-
-					/* must convert from network byte order to host byte order */
-					switch(typsize)
-					{
-						case 1:
-							d = Int8GetDatum(*(int32 *)(PQgetvalue(res, 0, i)));
-							break;
-						case 2:
-							d = Int16GetDatum(ntohs(*(int32 *)(PQgetvalue(res, 0, i))));
-							break;
-						case 4:
-							d = Int32GetDatum(ntohl(*(int32 *)(PQgetvalue(res, 0, i))));
-							break;
-						case 8:
-							x.i8 = *(int64 *)(PQgetvalue(res, 0, i));
+					case 1:
+						d = Int8GetDatum(*(int32 *)(PQgetvalue(res, 0, colpos)));
+						break;
+					case 2:
+						d = Int16GetDatum(ntohs(*(int32 *)(PQgetvalue(res, 0, colpos))));
+						break;
+					case 4:
+						d = Int32GetDatum(ntohl(*(int32 *)(PQgetvalue(res, 0, colpos))));
+						break;
+					case 8:
+						x.i8 = *(int64 *)(PQgetvalue(res, 0, colpos));
 #ifndef WORDS_BIGENDIAN
-							s = ntohl(x.i4[0]);
-							x.i4[0] = ntohl(x.i4[1]);
-							x.i4[1] = s;
+						s = ntohl(x.i4[0]);
+						x.i4[0] = ntohl(x.i4[1]);
+						x.i4[1] = s;
 #endif
-							d = Int64GetDatum(x.i8);
-							break;
-					}
+						d = Int64GetDatum(x.i8);
+						break;
 				}
-
-				values[i] = d;
 			}
+
+			values[i] = d;
 		}
 
 		tuple = heap_form_tuple(tupdesc, values, nulls);
@@ -336,10 +349,12 @@ plproxy_tuple_from_result(PGresult *res, TupleDesc tupdesc, ProxyFunction *func)
 		/* tuple consists of textual data */
 		for (i = 0; i < nfields; i++)
 		{
-			if (PQgetisnull(res, 0, i))
+			int colpos = conn->result_map ? conn->result_map[i] : i;
+
+			if (PQgetisnull(res, 0, colpos))
 				values[i] = NULL;
 			else
-				values[i] = PQgetvalue(res, 0, i);
+				values[i] = PQgetvalue(res, 0, colpos);
 		}
 
 		tuple = BuildTupleFromCStrings(attinmeta, values);

--- a/src/result.c
+++ b/src/result.c
@@ -220,3 +220,133 @@ plproxy_result(ProxyFunction *func, FunctionCallInfo fcinfo)
 
 	return dat;
 }
+
+/*
+ * Build a HeapTuple from a single-row query result.
+ */
+HeapTuple
+plproxy_tuple_from_result(PGresult *res, TupleDesc tupdesc, ProxyFunction *func)
+{
+	int	nfields = PQnfields(res);
+	HeapTuple tuple;
+	MemoryContext old_ctx;
+
+	/*
+	 * check result and tuple descriptor have the same number of columns
+	 */
+	if (PQnfields(res) != tupdesc->natts)
+		ereport(ERROR,
+				(errcode(ERRCODE_DATATYPE_MISMATCH),
+				 errmsg("remote query result rowtype does not match "
+						"the specified FROM clause rowtype")));
+
+	/* switch to temporary memory context */
+	old_ctx = MemoryContextSwitchTo(func->tuplectx);
+	/* clear temporary memory context */
+	MemoryContextReset(func->tuplectx);
+
+	/*
+	 * We can safely assume that the values are either all binary
+	 * or all textual.
+	 */
+	if (nfields > 0 && PQfformat(res, 0) == 1)
+	{
+		/*
+		 * This branch is currently dead code, since binary mode has been
+		 * disabled in 4a8a66270b29f78c9d5c082852ca26902517a7e4
+		 */
+		Datum *values = (Datum *) palloc(nfields * sizeof(Datum));
+		bool  *nulls = (bool *) palloc(nfields * sizeof(bool));
+		int    i;
+
+		/* result contains only binary data */
+		for (i = 0; i < nfields; i++)
+		{
+			if (PQgetisnull(res, 0, i))
+				nulls[i] = true;
+			else
+			{
+				Datum d;
+				int typsize;
+
+				nulls[i] = false;
+
+				/* convert binary representation to Datum */
+				if ((typsize = PQfsize(res, i)) == -1)
+				{
+					/* varlena */
+					int dlen = PQgetlength(res, 0, i);
+					struct varlena *v = palloc(dlen + VARHDRSZ);
+
+					SET_VARSIZE(v, dlen + VARHDRSZ);
+					memcpy(VARDATA(v), PQgetvalue(res, 0, i), dlen);
+
+					d = PointerGetDatum(v);
+				}
+				else
+				{
+					union {
+						int32 i4[2];
+						int64 i8;
+					} x;
+					int32 s;
+
+					/* must convert from network byte order to host byte order */
+					switch(typsize)
+					{
+						case 1:
+							d = Int8GetDatum(*(int32 *)(PQgetvalue(res, 0, i)));
+							break;
+						case 2:
+							d = Int16GetDatum(ntohs(*(int32 *)(PQgetvalue(res, 0, i))));
+							break;
+						case 4:
+							d = Int32GetDatum(ntohl(*(int32 *)(PQgetvalue(res, 0, i))));
+							break;
+						case 8:
+							x.i8 = *(int64 *)(PQgetvalue(res, 0, i));
+#ifndef WORDS_BIGENDIAN
+							s = ntohl(x.i4[0]);
+							x.i4[0] = ntohl(x.i4[1]);
+							x.i4[1] = s;
+#endif
+							d = Int64GetDatum(x.i8);
+							break;
+					}
+				}
+
+				values[i] = d;
+			}
+		}
+
+		tuple = heap_form_tuple(tupdesc, values, nulls);
+	}
+	else
+	{
+		int				i;
+		char		  **values;
+		AttInMetadata  *attinmeta = TupleDescGetAttInMetadata(tupdesc);
+
+		/* result contains only textual data */
+		if (nfields > 0)
+			values = (char **) palloc(nfields * sizeof(char *));
+		else
+			values = NULL;
+
+		/* tuple consists of textual data */
+		for (i = 0; i < nfields; i++)
+		{
+			if (PQgetisnull(res, 0, i))
+				values[i] = NULL;
+			else
+				values[i] = PQgetvalue(res, 0, i);
+		}
+
+		tuple = BuildTupleFromCStrings(attinmeta, values);
+	}
+
+	/* switch back to persistent memory context */
+	(void)MemoryContextSwitchTo(old_ctx);
+
+	return tuple;
+}

--- a/src/scanner.l
+++ b/src/scanner.l
@@ -172,6 +172,7 @@ ALL			[Aa][Ll][Ll]
 ANY			[Aa][Nn][Yy]
 SPLIT		[Ss][Pp][Ll][Ii][Tt]
 TARGET		[Tt][Aa][Rr][Gg][Ee][Tt]
+EXECUTE		[Ee][Xx][Ee][Cc][Uu][Tt][Ee]
 SELECT		[Ss][Ee][Ll][Ee][Cc][Tt]
 
 %%
@@ -186,6 +187,7 @@ SELECT		[Ss][Ee][Ll][Ee][Cc][Tt]
 {ANY}		{ return ANY; }
 {SPLIT}		{ return SPLIT; }
 {TARGET}	{ return TARGET; }
+{EXECUTE}	{ return EXECUTE; }
 {SELECT}	{ BEGIN(sql); yylval.str = yytext; return SELECT; }
 
 	/* function call */

--- a/test/expected/plproxy_execute.out
+++ b/test/expected/plproxy_execute.out
@@ -1,0 +1,161 @@
+\c regression
+create or replace function plproxy.get_cluster_partitions(cluster_name text)
+returns setof text as $$
+begin
+    if cluster_name = 'testcluster' then
+        return next 'host=127.0.0.1 dbname=test_part0';
+        return next 'host=127.0.0.1 dbname=test_part1';
+        return next 'host=127.0.0.1 dbname=test_part2';
+        return next 'host=127.0.0.1 dbname=test_part3';
+        return;
+    end if;
+    raise exception 'no such cluster: %', cluster_name;
+end; $$ language plpgsql;
+CREATE TABLE my_table (dbname text, i int);
+-- same query on all nodes
+CREATE OR REPLACE FUNCTION test_execute_single_on_all(query text) RETURNS SETOF my_table AS $$
+cluster 'testcluster';
+run on all;
+execute query;
+$$ LANGUAGE plproxy;
+SELECT * FROM test_execute_single_on_all('SELECT current_database() AS dbname, 1 AS i') ORDER BY dbname;
+   dbname   | i 
+------------+---
+ test_part0 | 1
+ test_part1 | 1
+ test_part2 | 1
+ test_part3 | 1
+(4 rows)
+
+-- Null means nothing gets executed
+SELECT * FROM test_execute_single_on_all(NULL) ORDER BY dbname;
+ dbname | i 
+--------+---
+(0 rows)
+
+-- Wrong datatype is validated
+CREATE OR REPLACE FUNCTION test_execute_wrong_datatype(query int) RETURNS SETOF my_table AS $$
+cluster 'testcluster';
+execute query;
+$$ LANGUAGE plproxy;
+ERROR:  PL/Proxy function public.test_execute_wrong_datatype(1): EXECUTE parameter is not text: query
+CREATE OR REPLACE FUNCTION test_execute_wrong_datatype(query int[]) RETURNS SETOF my_table AS $$
+cluster 'testcluster';
+execute query;
+$$ LANGUAGE plproxy;
+ERROR:  PL/Proxy function public.test_execute_wrong_datatype(1): EXECUTE parameter is not text: query
+-- Same query on specific nodes
+CREATE OR REPLACE FUNCTION test_execute_single_on_some(nodes int[], query text) RETURNS SETOF my_table AS $$
+cluster 'testcluster';
+split nodes;
+run on nodes;
+execute query;
+$$ LANGUAGE plproxy;
+SELECT * FROM test_execute_single_on_some(array[0,2], 'SELECT current_database() AS dbname, 1 AS i');
+   dbname   | i 
+------------+---
+ test_part0 | 1
+ test_part2 | 1
+(2 rows)
+
+-- All queries on all nodes. Maximum of 1 query for now.
+CREATE OR REPLACE FUNCTION test_execute_multiple_on_all(queries text[]) RETURNS SETOF my_table AS $$
+cluster 'testcluster';
+split queries;
+run on all;
+execute queries;
+$$ LANGUAGE plproxy;
+SELECT * FROM test_execute_multiple_on_all(array[
+	'SELECT current_database() AS dbname, 1 AS i',
+	'SELECT current_database() AS dbname, 2 AS i'
+]);
+ERROR:  PL/Proxy function public.test_execute_multiple_on_all(1): All partitions must get at most one query
+SELECT * FROM test_execute_multiple_on_all(array[
+	'SELECT current_database() AS dbname, 1 AS i',
+	NULL
+]);
+   dbname   | i 
+------------+---
+ test_part0 | 1
+ test_part1 | 1
+ test_part2 | 1
+ test_part3 | 1
+(4 rows)
+
+-- Specify one query per node
+CREATE OR REPLACE FUNCTION test_execute_multiple_on_specific(queries text[], nodes int[]) RETURNS SETOF my_table AS $$
+cluster 'testcluster';
+split nodes, queries;
+run on nodes;
+execute queries;
+$$ LANGUAGE plproxy;
+SELECT * FROM test_execute_multiple_on_specific(array[
+	'SELECT current_database() AS dbname, 1 AS i',
+	'SELECT current_database() AS dbname, 2 AS i'
+], array[3,0]);
+   dbname   | i 
+------------+---
+ test_part3 | 1
+ test_part0 | 2
+(2 rows)
+
+-- Null queries get skipped 
+SELECT * FROM test_execute_multiple_on_specific(array[
+	NULL,
+	'SELECT current_database() AS dbname, 1 AS i',
+	'SELECT current_database() AS dbname, 2 AS i',
+	NULL
+], array[0,1,2,3]);
+   dbname   | i 
+------------+---
+ test_part1 | 1
+ test_part2 | 2
+(2 rows)
+
+-- Array of queries not split is validated
+CREATE OR REPLACE FUNCTION test_execute_multiple_no_split(queries text[], nodes int[]) RETURNS SETOF my_table AS $$
+cluster 'testcluster';
+split nodes;
+run on nodes;
+execute queries;
+$$ LANGUAGE plproxy;
+ERROR:  PL/Proxy function public.test_execute_multiple_no_split(2): Compile error at line 6: EXECUTE argument is an array, but is not split
+-- Split queries on single node works when only one query
+CREATE OR REPLACE FUNCTION test_execute_multiple_on_single(queries text[], node int) RETURNS SETOF my_table AS $$
+cluster 'testcluster';
+split queries;
+run on node;
+execute queries;
+$$ LANGUAGE plproxy;
+SELECT * FROM test_execute_multiple_on_single(array[
+	'SELECT current_database() AS dbname, 1 AS i',
+	'SELECT current_database() AS dbname, 2 AS i'
+], 3);
+ERROR:  PL/Proxy function public.test_execute_multiple_on_single(2): All partitions must get at most one query
+SELECT * FROM test_execute_multiple_on_single(array[
+	'SELECT current_database() AS dbname, 1 AS i',
+	NULL
+], 3);
+   dbname   | i 
+------------+---
+ test_part3 | 1
+(1 row)
+
+-- No queries means no results
+SELECT * FROM test_execute_multiple_on_single(array[]::text[], 3);
+ dbname | i 
+--------+---
+(0 rows)
+
+-- Run one query on specific node
+CREATE OR REPLACE FUNCTION test_execute_single_on_single(node int, query text) RETURNS SETOF my_table AS $$
+cluster 'testcluster';
+run on node;
+execute query;
+$$ LANGUAGE plproxy;
+SELECT * FROM test_execute_single_on_single(0, 'SELECT current_database() AS dbname, 1 AS i');
+   dbname   | i 
+------------+---
+ test_part0 | 1
+(1 row)
+

--- a/test/expected/plproxy_execute.out
+++ b/test/expected/plproxy_execute.out
@@ -18,7 +18,7 @@ cluster 'testcluster';
 run on all;
 execute query;
 $$ LANGUAGE plproxy;
-SELECT * FROM test_execute_single_on_all('SELECT current_database() AS dbname, 1 AS i') ORDER BY dbname;
+SELECT * FROM test_execute_single_on_all('SELECT current_database() AS dbname, 1 AS i') ORDER BY dbname, i;
    dbname   | i 
 ------------+---
  test_part0 | 1
@@ -51,7 +51,7 @@ split nodes;
 run on nodes;
 execute query;
 $$ LANGUAGE plproxy;
-SELECT * FROM test_execute_single_on_some(array[0,2], 'SELECT current_database() AS dbname, 1 AS i');
+SELECT * FROM test_execute_single_on_some(array[0,2], 'SELECT current_database() AS dbname, 1 AS i') ORDER BY dbname, i;
    dbname   | i 
 ------------+---
  test_part0 | 1
@@ -73,7 +73,7 @@ ERROR:  PL/Proxy function public.test_execute_multiple_on_all(1): All partitions
 SELECT * FROM test_execute_multiple_on_all(array[
 	'SELECT current_database() AS dbname, 1 AS i',
 	NULL
-]);
+]) ORDER BY dbname, i;
    dbname   | i 
 ------------+---
  test_part0 | 1
@@ -92,11 +92,11 @@ $$ LANGUAGE plproxy;
 SELECT * FROM test_execute_multiple_on_specific(array[
 	'SELECT current_database() AS dbname, 1 AS i',
 	'SELECT current_database() AS dbname, 2 AS i'
-], array[3,0]);
+], array[3,0]) ORDER BY dbname, i;
    dbname   | i 
 ------------+---
- test_part3 | 1
  test_part0 | 2
+ test_part3 | 1
 (2 rows)
 
 -- Null queries get skipped 
@@ -105,7 +105,7 @@ SELECT * FROM test_execute_multiple_on_specific(array[
 	'SELECT current_database() AS dbname, 1 AS i',
 	'SELECT current_database() AS dbname, 2 AS i',
 	NULL
-], array[0,1,2,3]);
+], array[0,1,2,3]) ORDER BY dbname, i;
    dbname   | i 
 ------------+---
  test_part1 | 1

--- a/test/expected/plproxy_split.out
+++ b/test/expected/plproxy_split.out
@@ -78,19 +78,19 @@ ERROR:  PL/Proxy function public.test_array(3): split multi-dimensional arrays a
 -- run on array hash, split one array
 create or replace function test_array(a text[], b text[], c text) returns setof text as
 $$ split a; cluster 'testcluster'; run on ascii(a);$$ language plproxy;
-select * from test_array(array['a','b','c','d'], array['e','f','g','h'], 'foo');
+select * from test_array(array['a','b','c','d'], array['e','f','g','h'], 'foo') ORDER BY 1;
             test_array             
 -----------------------------------
+ test_part0 $1:d $2:e,f,g,h $3:foo
  test_part1 $1:a $2:e,f,g,h $3:foo
  test_part2 $1:b $2:e,f,g,h $3:foo
  test_part3 $1:c $2:e,f,g,h $3:foo
- test_part0 $1:d $2:e,f,g,h $3:foo
 (4 rows)
 
 -- run on text hash, split two arrays (nop split)
 create or replace function test_array(a text[], b text[], c text) returns setof text as
 $$ split a, b; cluster 'testcluster'; run on ascii(c);$$ language plproxy;
-select * from test_array(array['a','b','c','d'], array['e','f','g','h'], 'foo');
+select * from test_array(array['a','b','c','d'], array['e','f','g','h'], 'foo') ORDER BY 1;
                test_array                
 -----------------------------------------
  test_part2 $1:a,b,c,d $2:e,f,g,h $3:foo
@@ -99,13 +99,13 @@ select * from test_array(array['a','b','c','d'], array['e','f','g','h'], 'foo');
 -- run on array hash, split two arrays
 create or replace function test_array(a text[], b text[], c text) returns setof text as
 $$ split a, b; cluster 'testcluster'; run on ascii(a);$$ language plproxy;
-select * from test_array(array['a','b','c','d'], array['e','f','g','h'], 'foo');
+select * from test_array(array['a','b','c','d'], array['e','f','g','h'], 'foo') ORDER BY 1;
          test_array          
 -----------------------------
+ test_part0 $1:d $2:h $3:foo
  test_part1 $1:a $2:e $3:foo
  test_part2 $1:b $2:f $3:foo
  test_part3 $1:c $2:g $3:foo
- test_part0 $1:d $2:h $3:foo
 (4 rows)
 
 select * from test_array(null, null, null);
@@ -121,7 +121,7 @@ select * from test_array('{}'::text[], '{}'::text[], 'foo');
 -- run on text hash, split all arrays
 create or replace function test_array(a text[], b text[], c text) returns setof text as
 $$ split all; cluster 'testcluster'; run on ascii(c);$$ language plproxy;
-select * from test_array(array['a','b','c','d'], array['e','f','g','h'], 'foo');
+select * from test_array(array['a','b','c','d'], array['e','f','g','h'], 'foo') ORDER BY 1;
                test_array                
 -----------------------------------------
  test_part2 $1:a,b,c,d $2:e,f,g,h $3:foo
@@ -140,19 +140,19 @@ select * from test_nonarray_split('a', 'b', 'c');
 -- run on array hash, split all arrays
 create or replace function test_array(a text[], b text[], c text) returns setof text as
 $$ split all; cluster 'testcluster'; run on ascii(a);$$ language plproxy;
-select * from test_array(array['a','b','c','d'], array['e','f','g','h'], 'foo');
+select * from test_array(array['a','b','c','d'], array['e','f','g','h'], 'foo') ORDER BY 1;
          test_array          
 -----------------------------
+ test_part0 $1:d $2:h $3:foo
  test_part1 $1:a $2:e $3:foo
  test_part2 $1:b $2:f $3:foo
  test_part3 $1:c $2:g $3:foo
- test_part0 $1:d $2:h $3:foo
 (4 rows)
 
 -- run on arg
 create or replace function test_array_direct(a integer[], b text[], c text) returns setof text as
 $$ split a; cluster 'testcluster'; run on a; select test_array('{}'::text[], b, c);$$ language plproxy;
-select * from test_array_direct(array[2,3], array['a','b','c','d'], 'foo');
+select * from test_array_direct(array[2,3], array['a','b','c','d'], 'foo') ORDER BY 1;
         test_array_direct         
 ----------------------------------
  test_part2 $1: $2:a,b,c,d $3:foo
@@ -161,7 +161,7 @@ select * from test_array_direct(array[2,3], array['a','b','c','d'], 'foo');
 
 create or replace function test_array_direct(a integer[], b text[], c text) returns setof text as
 $$ split a, b; cluster 'testcluster'; run on a; select test_array('{}'::text[], b, c);$$ language plproxy;
-select * from test_array_direct(array[0,1,2,3], array['a','b','c','d'], 'foo');
+select * from test_array_direct(array[0,1,2,3], array['a','b','c','d'], 'foo') ORDER BY 1;
      test_array_direct      
 ----------------------------
  test_part0 $1: $2:a $3:foo

--- a/test/expected/plproxy_table.out
+++ b/test/expected/plproxy_table.out
@@ -36,3 +36,43 @@ select * from test_ret_table(0);
   2 | toto
 (2 rows)
 
+-- test table result set mapping
+\c test_part0
+CREATE FUNCTION test_result_map()
+   RETURNS TABLE (a integer, b text) AS
+$$SELECT a, b FROM (VALUES (1, 'one'), (2, 'two')) AS v(a, b)$$
+LANGUAGE sql;
+\c test_part1
+CREATE FUNCTION test_result_map()
+   RETURNS TABLE (b text, a integer) AS
+$$SELECT b, a FROM (VALUES (3, 'three'), (4, 'four')) AS v(a, b)$$
+LANGUAGE sql;
+\c test_part2
+CREATE FUNCTION test_result_map()
+   RETURNS TABLE (a integer, b text) AS
+$$SELECT a, b FROM (VALUES (5, 'five'), (6, 'six')) AS v(a, b)$$
+LANGUAGE sql;
+\c test_part3
+CREATE FUNCTION test_result_map()
+   RETURNS TABLE (b text, a integer) AS
+$$SELECT b, a FROM (VALUES (7, 'seven'), (8, 'eight')) AS v(a, b)$$
+LANGUAGE sql;
+\c regression
+CREATE FUNCTION test_result_map()
+   RETURNS TABLE (a integer, b text) AS
+$$CLUSTER 'testcluster';
+RUN ON ALL;$$
+LANGUAGE plproxy;
+SELECT * FROM test_result_map() ORDER BY a, b;
+ a |   b   
+---+-------
+ 1 | one
+ 2 | two
+ 3 | three
+ 4 | four
+ 5 | five
+ 6 | six
+ 7 | seven
+ 8 | eight
+(8 rows)
+

--- a/test/sql/plproxy_execute.sql
+++ b/test/sql/plproxy_execute.sql
@@ -22,7 +22,7 @@ run on all;
 execute query;
 $$ LANGUAGE plproxy;
 
-SELECT * FROM test_execute_single_on_all('SELECT current_database() AS dbname, 1 AS i') ORDER BY dbname;
+SELECT * FROM test_execute_single_on_all('SELECT current_database() AS dbname, 1 AS i') ORDER BY dbname, i;
 -- Null means nothing gets executed
 SELECT * FROM test_execute_single_on_all(NULL) ORDER BY dbname;
 
@@ -45,7 +45,7 @@ run on nodes;
 execute query;
 $$ LANGUAGE plproxy;
 
-SELECT * FROM test_execute_single_on_some(array[0,2], 'SELECT current_database() AS dbname, 1 AS i');
+SELECT * FROM test_execute_single_on_some(array[0,2], 'SELECT current_database() AS dbname, 1 AS i') ORDER BY dbname, i;
 
 -- All queries on all nodes. Maximum of 1 query for now.
 CREATE OR REPLACE FUNCTION test_execute_multiple_on_all(queries text[]) RETURNS SETOF my_table AS $$
@@ -62,7 +62,7 @@ SELECT * FROM test_execute_multiple_on_all(array[
 SELECT * FROM test_execute_multiple_on_all(array[
 	'SELECT current_database() AS dbname, 1 AS i',
 	NULL
-]);
+]) ORDER BY dbname, i;
 
 -- Specify one query per node
 CREATE OR REPLACE FUNCTION test_execute_multiple_on_specific(queries text[], nodes int[]) RETURNS SETOF my_table AS $$
@@ -75,14 +75,14 @@ $$ LANGUAGE plproxy;
 SELECT * FROM test_execute_multiple_on_specific(array[
 	'SELECT current_database() AS dbname, 1 AS i',
 	'SELECT current_database() AS dbname, 2 AS i'
-], array[3,0]);
+], array[3,0]) ORDER BY dbname, i;
 -- Null queries get skipped 
 SELECT * FROM test_execute_multiple_on_specific(array[
 	NULL,
 	'SELECT current_database() AS dbname, 1 AS i',
 	'SELECT current_database() AS dbname, 2 AS i',
 	NULL
-], array[0,1,2,3]);
+], array[0,1,2,3]) ORDER BY dbname, i;
 
 -- Array of queries not split is validated
 CREATE OR REPLACE FUNCTION test_execute_multiple_no_split(queries text[], nodes int[]) RETURNS SETOF my_table AS $$

--- a/test/sql/plproxy_execute.sql
+++ b/test/sql/plproxy_execute.sql
@@ -1,0 +1,123 @@
+\c regression
+
+create or replace function plproxy.get_cluster_partitions(cluster_name text)
+returns setof text as $$
+begin
+    if cluster_name = 'testcluster' then
+        return next 'host=127.0.0.1 dbname=test_part0';
+        return next 'host=127.0.0.1 dbname=test_part1';
+        return next 'host=127.0.0.1 dbname=test_part2';
+        return next 'host=127.0.0.1 dbname=test_part3';
+        return;
+    end if;
+    raise exception 'no such cluster: %', cluster_name;
+end; $$ language plpgsql;
+
+CREATE TABLE my_table (dbname text, i int);
+
+-- same query on all nodes
+CREATE OR REPLACE FUNCTION test_execute_single_on_all(query text) RETURNS SETOF my_table AS $$
+cluster 'testcluster';
+run on all;
+execute query;
+$$ LANGUAGE plproxy;
+
+SELECT * FROM test_execute_single_on_all('SELECT current_database() AS dbname, 1 AS i') ORDER BY dbname;
+-- Null means nothing gets executed
+SELECT * FROM test_execute_single_on_all(NULL) ORDER BY dbname;
+
+-- Wrong datatype is validated
+CREATE OR REPLACE FUNCTION test_execute_wrong_datatype(query int) RETURNS SETOF my_table AS $$
+cluster 'testcluster';
+execute query;
+$$ LANGUAGE plproxy;
+
+CREATE OR REPLACE FUNCTION test_execute_wrong_datatype(query int[]) RETURNS SETOF my_table AS $$
+cluster 'testcluster';
+execute query;
+$$ LANGUAGE plproxy;
+
+-- Same query on specific nodes
+CREATE OR REPLACE FUNCTION test_execute_single_on_some(nodes int[], query text) RETURNS SETOF my_table AS $$
+cluster 'testcluster';
+split nodes;
+run on nodes;
+execute query;
+$$ LANGUAGE plproxy;
+
+SELECT * FROM test_execute_single_on_some(array[0,2], 'SELECT current_database() AS dbname, 1 AS i');
+
+-- All queries on all nodes. Maximum of 1 query for now.
+CREATE OR REPLACE FUNCTION test_execute_multiple_on_all(queries text[]) RETURNS SETOF my_table AS $$
+cluster 'testcluster';
+split queries;
+run on all;
+execute queries;
+$$ LANGUAGE plproxy;
+
+SELECT * FROM test_execute_multiple_on_all(array[
+	'SELECT current_database() AS dbname, 1 AS i',
+	'SELECT current_database() AS dbname, 2 AS i'
+]);
+SELECT * FROM test_execute_multiple_on_all(array[
+	'SELECT current_database() AS dbname, 1 AS i',
+	NULL
+]);
+
+-- Specify one query per node
+CREATE OR REPLACE FUNCTION test_execute_multiple_on_specific(queries text[], nodes int[]) RETURNS SETOF my_table AS $$
+cluster 'testcluster';
+split nodes, queries;
+run on nodes;
+execute queries;
+$$ LANGUAGE plproxy;
+
+SELECT * FROM test_execute_multiple_on_specific(array[
+	'SELECT current_database() AS dbname, 1 AS i',
+	'SELECT current_database() AS dbname, 2 AS i'
+], array[3,0]);
+-- Null queries get skipped 
+SELECT * FROM test_execute_multiple_on_specific(array[
+	NULL,
+	'SELECT current_database() AS dbname, 1 AS i',
+	'SELECT current_database() AS dbname, 2 AS i',
+	NULL
+], array[0,1,2,3]);
+
+-- Array of queries not split is validated
+CREATE OR REPLACE FUNCTION test_execute_multiple_no_split(queries text[], nodes int[]) RETURNS SETOF my_table AS $$
+cluster 'testcluster';
+split nodes;
+run on nodes;
+execute queries;
+$$ LANGUAGE plproxy;
+
+-- Split queries on single node works when only one query
+CREATE OR REPLACE FUNCTION test_execute_multiple_on_single(queries text[], node int) RETURNS SETOF my_table AS $$
+cluster 'testcluster';
+split queries;
+run on node;
+execute queries;
+$$ LANGUAGE plproxy;
+
+SELECT * FROM test_execute_multiple_on_single(array[
+	'SELECT current_database() AS dbname, 1 AS i',
+	'SELECT current_database() AS dbname, 2 AS i'
+], 3);
+
+SELECT * FROM test_execute_multiple_on_single(array[
+	'SELECT current_database() AS dbname, 1 AS i',
+	NULL
+], 3);
+
+-- No queries means no results
+SELECT * FROM test_execute_multiple_on_single(array[]::text[], 3);
+
+-- Run one query on specific node
+CREATE OR REPLACE FUNCTION test_execute_single_on_single(node int, query text) RETURNS SETOF my_table AS $$
+cluster 'testcluster';
+run on node;
+execute query;
+$$ LANGUAGE plproxy;
+
+SELECT * FROM test_execute_single_on_single(0, 'SELECT current_database() AS dbname, 1 AS i');

--- a/test/sql/plproxy_split.sql
+++ b/test/sql/plproxy_split.sql
@@ -61,24 +61,24 @@ select * from test_array(array[array['a1'],array['a2']], array[array['b1'],array
 -- run on array hash, split one array
 create or replace function test_array(a text[], b text[], c text) returns setof text as
 $$ split a; cluster 'testcluster'; run on ascii(a);$$ language plproxy;
-select * from test_array(array['a','b','c','d'], array['e','f','g','h'], 'foo');
+select * from test_array(array['a','b','c','d'], array['e','f','g','h'], 'foo') ORDER BY 1;
 
 -- run on text hash, split two arrays (nop split)
 create or replace function test_array(a text[], b text[], c text) returns setof text as
 $$ split a, b; cluster 'testcluster'; run on ascii(c);$$ language plproxy;
-select * from test_array(array['a','b','c','d'], array['e','f','g','h'], 'foo');
+select * from test_array(array['a','b','c','d'], array['e','f','g','h'], 'foo') ORDER BY 1;
 
 -- run on array hash, split two arrays
 create or replace function test_array(a text[], b text[], c text) returns setof text as
 $$ split a, b; cluster 'testcluster'; run on ascii(a);$$ language plproxy;
-select * from test_array(array['a','b','c','d'], array['e','f','g','h'], 'foo');
+select * from test_array(array['a','b','c','d'], array['e','f','g','h'], 'foo') ORDER BY 1;
 select * from test_array(null, null, null);
 select * from test_array('{}'::text[], '{}'::text[], 'foo');
 
 -- run on text hash, split all arrays
 create or replace function test_array(a text[], b text[], c text) returns setof text as
 $$ split all; cluster 'testcluster'; run on ascii(c);$$ language plproxy;
-select * from test_array(array['a','b','c','d'], array['e','f','g','h'], 'foo');
+select * from test_array(array['a','b','c','d'], array['e','f','g','h'], 'foo') ORDER BY 1;
 
 -- run on text hash, attempt to split all arrays but none are present
 create or replace function test_nonarray_split(a text, b text, c text) returns setof text as
@@ -89,15 +89,15 @@ select * from test_nonarray_split('a', 'b', 'c');
 -- run on array hash, split all arrays
 create or replace function test_array(a text[], b text[], c text) returns setof text as
 $$ split all; cluster 'testcluster'; run on ascii(a);$$ language plproxy;
-select * from test_array(array['a','b','c','d'], array['e','f','g','h'], 'foo');
+select * from test_array(array['a','b','c','d'], array['e','f','g','h'], 'foo') ORDER BY 1;
 
 -- run on arg
 create or replace function test_array_direct(a integer[], b text[], c text) returns setof text as
 $$ split a; cluster 'testcluster'; run on a; select test_array('{}'::text[], b, c);$$ language plproxy;
 
-select * from test_array_direct(array[2,3], array['a','b','c','d'], 'foo');
+select * from test_array_direct(array[2,3], array['a','b','c','d'], 'foo') ORDER BY 1;
 
 create or replace function test_array_direct(a integer[], b text[], c text) returns setof text as
 $$ split a, b; cluster 'testcluster'; run on a; select test_array('{}'::text[], b, c);$$ language plproxy;
 
-select * from test_array_direct(array[0,1,2,3], array['a','b','c','d'], 'foo');
+select * from test_array_direct(array[0,1,2,3], array['a','b','c','d'], 'foo') ORDER BY 1;

--- a/test/sql/plproxy_table.sql
+++ b/test/sql/plproxy_table.sql
@@ -28,3 +28,42 @@ $$ language plproxy;
 
 select * from test_ret_table(0);
 
+-- test table result set mapping
+
+\c test_part0
+
+CREATE FUNCTION test_result_map()
+   RETURNS TABLE (a integer, b text) AS
+$$SELECT a, b FROM (VALUES (1, 'one'), (2, 'two')) AS v(a, b)$$
+LANGUAGE sql;
+
+\c test_part1
+
+CREATE FUNCTION test_result_map()
+   RETURNS TABLE (b text, a integer) AS
+$$SELECT b, a FROM (VALUES (3, 'three'), (4, 'four')) AS v(a, b)$$
+LANGUAGE sql;
+
+\c test_part2
+
+CREATE FUNCTION test_result_map()
+   RETURNS TABLE (a integer, b text) AS
+$$SELECT a, b FROM (VALUES (5, 'five'), (6, 'six')) AS v(a, b)$$
+LANGUAGE sql;
+
+\c test_part3
+
+CREATE FUNCTION test_result_map()
+   RETURNS TABLE (b text, a integer) AS
+$$SELECT b, a FROM (VALUES (7, 'seven'), (8, 'eight')) AS v(a, b)$$
+LANGUAGE sql;
+
+\c regression
+
+CREATE FUNCTION test_result_map()
+   RETURNS TABLE (a integer, b text) AS
+$$CLUSTER 'testcluster';
+RUN ON ALL;$$
+LANGUAGE plproxy;
+
+SELECT * FROM test_result_map() ORDER BY a, b;


### PR DESCRIPTION
This is an updated, consolidated version of #30, which can be closed now as obsolete.

These are two different features in three patches, as I will explain further down.

- f59ece9ec60b81c3084201f4ccabc1f1abba211f adds the new `EXECUTE` statement.
  The main benefit of this approach is that it avoids a function call on the remote side, which would disable parallel execution.
  This was written by @ants, who can answer detail questions on it.

- 130aa2b67d7bbe809f4278e4536a87c034694858 makes set-returning functions return their result in a tuplestore (`rsinfo->returnMode = SFRM_Materialize`).
  This avoids out-of memory situations with large result sets.
  For this, the client connections to the shards are set to operate in single-row mode (again to avoid OOM).
  This breaks the existing column name mapping between the result sets, since they are now not retrieved shard by shard.
  This shortcoming is fixed with e0aeffe11971fe87900f0b22fdfe36747ba024bc, which I have broken out as a separate patch, since it touches many places and would make 130aa2b67d7bbe809f4278e4536a87c034694858 less understandable when squashed together.

Currently the patches are in the order that we developed the features, so the second patch requires the first and so on.
I have done it like this for now, since I don't know if you are interested at all.
If you want only parts of this (say, the tuplestores, but not `EXECUTE`), I can create a separate pull request only for that.