### PR TITLE
Close connections properly on process exit

### DIFF
--- a/src/function.c
+++ b/src/function.c
@@ -149,6 +149,40 @@ plproxy_split_all_arrays(ProxyFunction *func)
 	}
 }
 
+static void close_all_connections(int code, Datum arg)
+{
+	HASH_SEQ_STATUS scan;
+	HashEntry *entry;
+
+	/* iterate through the function cache */
+	hash_seq_init(&scan, fn_cache);
+	while ((entry = (HashEntry *) hash_seq_search(&scan)))
+	{
+		ProxyFunction *func = entry->function;
+		ProxyCluster *cluster = func->cur_cluster;
+		int i;
+
+		if (!cluster)
+			continue;
+
+		/* close all connections of the function's cluster */
+		for (i = 0; i < cluster->part_count; i++)
+		{
+			ProxyConnection *conn = cluster->part_map[i];
+			ProxyConnectionState *cur;
+			struct AANode *node;
+
+			node = aatree_search(&conn->userstate_tree, (uintptr_t)cluster->cur_userinfo->username);
+			if (!node)
+				continue;
+
+			cur = container_of(node, ProxyConnectionState, node);
+			if (cur->db)
+				PQfinish(cur->db);
+		}
+	}
+}
+
 /* Initialize PL/Proxy function cache */
 void
 plproxy_function_cache_init(void)
@@ -166,6 +200,9 @@ plproxy_function_cache_init(void)
 	ctl.hash = oid_hash;
 	flags = HASH_ELEM | HASH_FUNCTION;
 	fn_cache = hash_create("PL/Proxy function cache", max_funcs, &ctl, flags);
+
+	/* make sure all connections are closed properly on exit */
+	on_proc_exit(&close_all_connections, Int32GetDatum(0));
 }
 
 

--- a/src/plproxy.h
+++ b/src/plproxy.h
@@ -47,6 +47,7 @@
 #include <mb/pg_wchar.h>
 #include <miscadmin.h>
 #include <nodes/value.h>
+#include <storage/ipc.h>
 #include <utils/acl.h>
 #include <utils/array.h>
 #include <utils/builtins.h>


### PR DESCRIPTION
PL/Proxy caches database connections to the shards, but didn't close them properly when the database session exits.  This does not affect the basic functionality, but has unpleasant consequences:

- these sessions are counted as "sessions_abandoned" in "pg_stat_database" on the remote side

- if the connection to the shard is TLS encrypted, ending the session logs these messages on the remote side:

  LOG:  SSL error: unexpected eof while reading
  LOG:  could not receive data from client: Connection reset by peer